### PR TITLE
Move Maestro options initializer to factory

### DIFF
--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -19,37 +19,6 @@ public final class Maestro {
         self.verbose = verbose
     }
 
-    /// Convenience initializer that builds the required pipeline components
-    /// from a set of `MaestroOptions` as parsed from the command line.
-    convenience init(options: MaestroOptions) {
-        let notificationPusher: NotificationPusher? = options.notificationsEnabled ?
-            HomeAssistantNotificationPusher(baseURL: options.baseURL, token: options.token) : nil
-        let logger = Logger(pusher: notificationPusher)
-
-        let states = HomeAssistantStateProvider(baseURL: options.baseURL, token: options.token)
-
-        let lights: LightController
-        if options.simulate {
-            lights = LoggingLightController()
-        } else {
-            let haLights = HomeAssistantLightController(baseURL: options.baseURL,
-                                                       token: options.token,
-                                                       logger: logger)
-            lights = options.verbose ?
-                MultiLightController([haLights, LoggingLightController()]) :
-                haLights
-        }
-
-        let program: LightProgram
-        switch options.programName.lowercased() {
-        case LightProgramSecondary().name:
-            program = LightProgramSecondary()
-        default:
-            program = LightProgramDefault()
-        }
-
-        self.init(states: states, lights: lights, program: program, logger: logger, verbose: options.verbose)
-    }
 
     /// Fetches state from Home Assistant and applies the current scene.
     /// 

--- a/maestro/swift/Sources/Core/MaestroFactory.swift
+++ b/maestro/swift/Sources/Core/MaestroFactory.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Builds a fully configured ``Maestro`` instance from command line options.
+func makeMaestro(from options: MaestroOptions) -> Maestro {
+    let notificationPusher: NotificationPusher? = options.notificationsEnabled ?
+        HomeAssistantNotificationPusher(baseURL: options.baseURL, token: options.token) : nil
+    let logger = Logger(pusher: notificationPusher)
+
+    let states = HomeAssistantStateProvider(baseURL: options.baseURL, token: options.token)
+
+    let lights: LightController
+    if options.simulate {
+        lights = LoggingLightController()
+    } else {
+        let haLights = HomeAssistantLightController(baseURL: options.baseURL,
+                                                   token: options.token,
+                                                   logger: logger)
+        lights = options.verbose ?
+            MultiLightController([haLights, LoggingLightController()]) :
+            haLights
+    }
+
+    let program: LightProgram
+    switch options.programName.lowercased() {
+    case LightProgramSecondary().name:
+        program = LightProgramSecondary()
+    default:
+        program = LightProgramDefault()
+    }
+
+    return Maestro(states: states,
+                   lights: lights,
+                   program: program,
+                   logger: logger,
+                   verbose: options.verbose)
+}

--- a/maestro/swift/Sources/Core/main.swift
+++ b/maestro/swift/Sources/Core/main.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 let options = parseArguments(CommandLine.arguments)
-let maestro = Maestro(options: options)
+let maestro = makeMaestro(from: options)
 try startServer(on: options.port, maestro: maestro)


### PR DESCRIPTION
## Summary
- drop the Maestro convenience initializer
- add a dedicated `makeMaestro(from:)` factory
- use the new factory in `main.swift`

## Testing
- `cd maestro/swift && swift test`

------
https://chatgpt.com/codex/tasks/task_e_684e404ec53c8326bb9ab76d54ff477e