### PR TITLE
Connect addon options to maestro CLI

### DIFF
--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -11,3 +11,22 @@ homeassistant_api: true
 ports:
   8080/tcp: 8080
 image: "ghcr.io/lucasfeijo/{arch}-addon-maestro"
+
+# Default option values exposed to the add-on UI. These are forwarded as
+# command line arguments to the Swift server via the service script.
+options:
+  baseurl: http://homeassistant.local:8123/
+  token: ''
+  simulate: false
+  no_notify: false
+  program: default
+  verbose: false
+
+# Option schema used by Home Assistant to validate user input.
+schema:
+  baseurl: str?
+  token: str?
+  simulate: bool
+  no_notify: bool
+  program: str?
+  verbose: bool

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.3"
+version: "1.0.4"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro

--- a/maestro/rootfs/etc/services.d/maestro/run
+++ b/maestro/rootfs/etc/services.d/maestro/run
@@ -1,3 +1,33 @@
 #!/usr/bin/with-contenv bashio
-# Start Hass Maestro Swift server
-exec /usr/bin/maestro
+# Start Hass Maestro Swift server with options from the add-on configuration.
+
+ARGS=()
+
+BASEURL=$(bashio::config 'baseurl')
+if [ -n "$BASEURL" ]; then
+    ARGS+=(--baseurl "$BASEURL")
+fi
+
+TOKEN=$(bashio::config 'token')
+if [ -n "$TOKEN" ]; then
+    ARGS+=(--token "$TOKEN")
+fi
+
+if bashio::config.true 'simulate'; then
+    ARGS+=(--simulate)
+fi
+
+if bashio::config.true 'no_notify'; then
+    ARGS+=(--no-notify)
+fi
+
+PROGRAM=$(bashio::config 'program')
+if [ -n "$PROGRAM" ]; then
+    ARGS+=(--program "$PROGRAM")
+fi
+
+if bashio::config.true 'verbose'; then
+    ARGS+=(--verbose)
+fi
+
+exec /usr/bin/maestro "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- define configurable options and schema in `maestro/config.yaml`
- forward addon options to the Swift server via `maestro/run`

## Testing
- `swift test --package-path maestro/swift`

------
https://chatgpt.com/codex/tasks/task_e_684e46fb4ed483269e5efd5c385a60a4