### PR TITLE
Fix entrypoint to run with s6 overlay

### DIFF
--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -7,3 +7,4 @@ RUN swift build -c release
 FROM $BUILD_FROM
 COPY rootfs /
 COPY --from=build /usr/src/app/.build/release/maestro /usr/bin/maestro
+ENTRYPOINT ["/init"]


### PR DESCRIPTION
## Summary
- ensure `/init` is the entrypoint so s6-overlay starts as PID 1

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684e50ca26a08326aa737c20b5fb887e