### PR TITLE
Fix entrypoint to run with s6 overlay

### DIFF
--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -7,3 +7,4 @@ RUN swift build -c release
 FROM $BUILD_FROM
 COPY rootfs /
 COPY --from=build /usr/src/app/.build/release/maestro /usr/bin/maestro
+ENTRYPOINT ["/init"]

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -6,6 +6,7 @@ url: https://github.com/lucasfeijo/hass-maestro
 arch:
   - aarch64
   - amd64
+init: false
 startup: services
 homeassistant_api: true
 ports:


### PR DESCRIPTION
## Summary
- ensure `/init` is the entrypoint so s6-overlay starts as PID 1
- disable Docker's default init so the overlay can launch

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_684e50ca26a08326aa737c20b5fb887e