### PR TITLE
Fix missing maestro binary

### DIFF
--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM swift:5.7 as build
 WORKDIR /usr/src/app
 COPY swift/ ./
-RUN swift build -c release
+RUN swift build -c release --static-swift-stdlib
 
 FROM $BUILD_FROM
 COPY rootfs /

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.6"
+version: "1.0.7"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro


### PR DESCRIPTION
## Summary
- build a static Swift binary in the Dockerfile to avoid missing runtime libraries

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684e5592184c832686f3779af4d8c8c6