### PR TITLE
Fix runtime glibc libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ swift run maestro
 The package builds on Linux and macOS. On macOS the POSIX server code uses the
 `Darwin` module, so the same command works there as well.
 
+### Runtime dependencies
+
+When running the Home Assistant add-on the container image is based on Alpine
+Linux. The server executable is built against glibc, so the runtime image needs
+glibc compatibility libraries. The provided Dockerfile installs `libc6-compat`
+and `gcompat` to supply these libraries. If you maintain a custom image ensure
+these packages are present or compile the server against musl instead.
+
 ## Requesting the server
 
 ### `GET /run`

--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && \
 RUN swift build -c release --static-swift-stdlib
 
 FROM $BUILD_FROM
-RUN apk add --no-cache libc6-compat libstdc++ gcompat \
+RUN apk add --no-cache libc6-compat libstdc++ \
+    && apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/main \
+       --repository https://dl-cdn.alpinelinux.org/alpine/edge/community gcompat \
     && mkdir -p /lib64 \
     && ln -sf /lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 COPY rootfs /

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.15"
+version: "1.0.16"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro


### PR DESCRIPTION
## Summary
- install `libc6-compat` and `gcompat` from edge repos
- bump add-on version
- document runtime dependencies

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e62b1490c83269558150ef89233b4