### PR TITLE
Add musl import fallback

### DIFF
--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -1,5 +1,7 @@
 import Foundation
-#if os(Linux)
+#if canImport(Musl)
+import Musl
+#elseif canImport(Glibc)
 import Glibc
 #else
 import Darwin


### PR DESCRIPTION
## Summary
- support building on musl by checking for Musl module in `StartServer.swift`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684f5893a0a4832684b9082d52c73499