### PR TITLE
Add debugging logs for binary path

### DIFF
--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -7,11 +7,13 @@ RUN swift sdk install https://download.swift.org/swift-6.1.2-release/static-sdk/
 
 WORKDIR /usr/src/app
 COPY swift/ ./
-RUN swift build -c release --swift-sdk aarch64-swift-linux-musl
+RUN swift build -c release --swift-sdk aarch64-swift-linux-musl \
+    && ls -al /usr/src/app/.build/release
 
 FROM ${BUILD_FROM}
 
 COPY rootfs/ /
 COPY --from=build /usr/src/app/.build/release/maestro /usr/bin/maestro
+RUN ls -al /usr/bin/maestro
 
 ENTRYPOINT ["/init"]

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.46"
+version: "1.0.47"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro

--- a/maestro/rootfs/etc/services.d/maestro/run
+++ b/maestro/rootfs/etc/services.d/maestro/run
@@ -30,4 +30,19 @@ if bashio::config.true 'verbose'; then
     ARGS+=(--verbose)
 fi
 
+echo "Debug: verifying maestro binary paths..." >&2
+if [ -f /usr/src/app/.build/release/maestro ]; then
+    echo "Found binary at /usr/src/app/.build/release/maestro" >&2
+else
+    echo "Binary missing at /usr/src/app/.build/release/maestro" >&2
+    ls -al /usr/src/app/.build/release >&2 || true
+fi
+
+if [ -f /usr/bin/maestro ]; then
+    echo "Found binary at /usr/bin/maestro" >&2
+else
+    echo "Binary missing at /usr/bin/maestro" >&2
+    ls -al /usr/bin >&2 || true
+fi
+
 exec /usr/src/app/.build/release/maestro "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- add logs to check maestro binary paths in the service run script
- print binary paths when building images

## Testing
- `swift test` *(fails: initializer 'init' requires '__socket_type' conform to BinaryFloatingPoint)*

------
https://chatgpt.com/codex/tasks/task_e_685255e85d708326b51683cbe67c330c