### PR TITLE
Use swift-argument-parser in CLI

### DIFF
--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.50"
+version: "1.0.51"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.49"
+version: "1.0.50"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro

--- a/maestro/swift/Package.swift
+++ b/maestro/swift/Package.swift
@@ -5,10 +5,16 @@ import PackageDescription
 
 let package = Package(
     name: "maestro",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
+    ],
     targets: [
         // Executable containing the HTTP server and orchestration logic.
         .executableTarget(
             name: "maestro",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
             path: "Sources"
         ),
         // Unit tests exercising the orchestration logic.
@@ -16,6 +22,10 @@ let package = Package(
             name: "maestroTests",
             dependencies: [
                 .target(name: "maestro")
-            ]),
+            ],
+            swiftSettings: [
+                .define("TESTING")
+            ]
+        ),
     ]
 )

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -12,7 +12,9 @@ import ucrt
 #endif
 /// Minimal HTTP server handling GET requests from Home Assistant.
 func startServer(on port: Int32, maestro: Maestro) throws {
-    let serverFD = socket(AF_INET, Int32(SOCK_STREAM), 0)
+    // SOCK_STREAM is an enum on modern glibc; use its raw value when
+    // converting to `Int32`.
+    let serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
     guard serverFD >= 0 else { fatalError("Unable to create socket") }
 
     var value: Int32 = 1

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -12,9 +12,14 @@ import ucrt
 #endif
 /// Minimal HTTP server handling GET requests from Home Assistant.
 func startServer(on port: Int32, maestro: Maestro) throws {
-    // SOCK_STREAM is an enum on modern glibc; use its raw value when
-    // converting to `Int32`.
+    // SOCK_STREAM became an enum in newer Swift/Glibc versions.  Older toolchains
+    // expect the plain integer constant.  Use conditional compilation so the code
+    // builds across Swift versions.
+#if swift(>=5.10)
     let serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+#else
+    let serverFD = socket(AF_INET, Int32(SOCK_STREAM), 0)
+#endif
     guard serverFD >= 0 else { fatalError("Unable to create socket") }
 
     var value: Int32 = 1

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -12,18 +12,10 @@ import ucrt
 #endif
 /// Minimal HTTP server handling GET requests from Home Assistant.
 func startServer(on port: Int32, maestro: Maestro) throws {
-    // SOCK_STREAM is an enum on modern Linux toolchains but a plain Int32 on
-    // Darwin and older Swift versions.  Use whichever expression compiles so
-    // the code builds everywhere.
-#if os(Linux)
-#if swift(>=5.10)
-    let serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
-#else
-    let serverFD = socket(AF_INET, Int32(SOCK_STREAM), 0)
-#endif
-#else
-    let serverFD = socket(AF_INET, SOCK_STREAM, 0)
-#endif
+    // SOCK_STREAM may be an enum or an Int32 depending on the libc headers
+    // being used. Convert it to Int32 in a way that works for both cases.
+    let sockStream: Int32 = withUnsafeBytes(of: SOCK_STREAM) { $0.load(as: Int32.self) }
+    let serverFD = socket(AF_INET, sockStream, 0)
     guard serverFD >= 0 else { fatalError("Unable to create socket") }
 
     var value: Int32 = 1

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -12,13 +12,17 @@ import ucrt
 #endif
 /// Minimal HTTP server handling GET requests from Home Assistant.
 func startServer(on port: Int32, maestro: Maestro) throws {
-    // SOCK_STREAM became an enum in newer Swift/Glibc versions.  Older toolchains
-    // expect the plain integer constant.  Use conditional compilation so the code
-    // builds across Swift versions.
+    // SOCK_STREAM is an enum on modern Linux toolchains but a plain Int32 on
+    // Darwin and older Swift versions.  Use whichever expression compiles so
+    // the code builds everywhere.
+#if os(Linux)
 #if swift(>=5.10)
     let serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
 #else
     let serverFD = socket(AF_INET, Int32(SOCK_STREAM), 0)
+#endif
+#else
+    let serverFD = socket(AF_INET, SOCK_STREAM, 0)
 #endif
     guard serverFD >= 0 else { fatalError("Unable to create socket") }
 

--- a/maestro/swift/Sources/Core/main.swift
+++ b/maestro/swift/Sources/Core/main.swift
@@ -2,4 +2,7 @@ import Foundation
 
 let options = parseArguments(CommandLine.arguments)
 let maestro = makeMaestro(from: options)
+#if !TESTING
 try startServer(on: options.port, maestro: maestro)
+#endif
+


### PR DESCRIPTION
## Summary
- integrate swift-argument-parser for command-line interface
- fix server socket initialization for new glibc enum
- avoid launching server when running tests
- merge MaestroArguments and MaestroOptions

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68536e0812088326a2580720a53bfb59