### PR TITLE
Fix color temp when leaving preset

### DIFF
--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -1,5 +1,5 @@
 name: Hass Maestro
-version: "1.0.49"
+version: "1.0.50"
 slug: maestro
 description: Home Assistant lights orchestrator
 url: https://github.com/lucasfeijo/hass-maestro

--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -72,35 +72,35 @@ public struct LightProgramDefault: LightProgram {
         case .normal:
             if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
                 if !environment.hyperionRunning {
-                    changes.on("light.tv_light", brightness: 50)
-                    changes.on("light.wled_tv_shelf_4", brightness: 20, effect: "solid")
+                    changes.on("light.tv_light", brightness: 50, colorTemperature: 224)
+                    changes.on("light.wled_tv_shelf_4", brightness: 20, rgbwColor: (7, 106, 168, 255), effect: "solid")
                 } else {
                     changes.off(["light.tv_light", "light.tv_shelf_group"])
                 }
-                changes.on("light.dining_table_light", brightness: 100)
+                changes.on("light.dining_table_light", brightness: 100, colorTemperature: 206)
                 changes.off("light.corner_light")
-                changes.on("light.desk_light", brightness: 40)
-                changes.on(["light.corredor_door_light", "light.entrance_dining_light", "light.living_entry_door_light"], brightness: 60)
-                changes.on("light.shoes_light", brightness: 50)
+                changes.on("light.desk_light", brightness: 40, colorTemperature: 199)
+                changes.on(["light.corredor_door_light", "light.entrance_dining_light", "light.living_entry_door_light"], brightness: 60, colorTemperature: 250)
+                changes.on("light.shoes_light", brightness: 50, colorTemperature: 250)
                 changes.off(["light.chaise_light", "light.window_led_strip"])
-                changes.on("light.living_art_wall_light", brightness: 60)
-                changes.on("light.tripod_lamp", brightness: 49)
+                changes.on("light.living_art_wall_light", brightness: 60, colorTemperature: 196)
+                changes.on("light.tripod_lamp", brightness: 49, colorTemperature: 206)
                 changes.off("light.living_fireplace_spot")
-                    changes.on("light.zigbee_hub_estante_lights", brightness: 55)
-                    changes.on("light.kitchen_led", brightness: 50, effect: "solid")
+                changes.on("light.zigbee_hub_estante_lights", brightness: 55, colorTemperature: 198)
+                changes.on("light.kitchen_led", brightness: 50, rgbwColor: (0, 0, 0, 255), effect: "solid")
             } else {
                 if !environment.hyperionRunning {
-                    changes.on("light.tv_light", brightness: 51)
-                    changes.on("light.tv_shelf_group", brightness: 20, effect: "solid")
+                    changes.on("light.tv_light", brightness: 51, colorTemperature: 394)
+                    changes.on("light.tv_shelf_group", brightness: 20, rgbwColor: (255, 158, 64, 255), effect: "solid")
                 } else {
                     changes.off("light.tv_light")
                 }
-                changes.on("light.color_lights_without_tv_light", brightness: 51)
-                changes.on("light.corner_light", brightness: 30)
-                changes.on("light.window_led_strip", brightness: 40, effect: "solid")
-                changes.on(["light.living_fireplace_spot", "light.living_entry_door_light", "light.shoes_light", "light.entrance_dining_light", "light.corredor_door_light"], brightness: 20)
+                changes.on("light.color_lights_without_tv_light", brightness: 51, colorTemperature: 394)
+                changes.on("light.corner_light", brightness: 30, colorTemperature: 394)
+                changes.on("light.window_led_strip", brightness: 40, rgbColor: (189, 157, 112), effect: "solid")
+                changes.on(["light.living_fireplace_spot", "light.living_entry_door_light", "light.shoes_light", "light.entrance_dining_light", "light.corredor_door_light"], brightness: 20, colorTemperature: 404)
                 changes.off("light.chaise_light")
-                changes.on("light.kitchen_led", brightness: 26, effect: "solid")
+                changes.on("light.kitchen_led", brightness: 26, rgbwColor: (230, 170, 30, 150), effect: "solid")
             }
 
         case .bright:


### PR DESCRIPTION
## Summary
- adjust `normal` scene to send proper color temperatures when leaving a preset scene

## Testing
- `swift test` *(fails: initializer 'init(_:)' requires that '__socket_type' conform to 'BinaryFloatingPoint')*

------
https://chatgpt.com/codex/tasks/task_e_6854dfe46d488326b576b0926e736e46