### PR TITLE
Improve CLI log readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,11 @@ swift run maestro
  --baseurl http://homeassistant.local:8123/ # base URL for the Home Assistant instance. The default is `http://homeassistant.local:8123/`
  --token YOUR_TOKEN # long lived Home Assistant token used for API calls
  --simulate # print light commands to stdout instead of sending them
---verbose # print commands while also sending them
---no-notify # disable Home Assistant persistent notifications on failures
---program secondary # choose the light program to run (`default` or `secondary`)
---port 8080 # port for the HTTP server (default 8080)
+ --verbose # print commands while also sending them
+ --no-notify # disable Home Assistant persistent notifications on failures
+ --program secondary # choose the light program to run (`default` or `secondary`)
+ --port 8080 # port for the HTTP server (default 8080)
 ```
-
-Light commands and errors are printed with ANSI colors when running in verbose
-or simulation mode to improve readability.
 
 The package builds on Linux and macOS. On macOS the POSIX server code uses the
 `Darwin` module, so the same command works there as well.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ swift run maestro
  --baseurl http://homeassistant.local:8123/ # base URL for the Home Assistant instance. The default is `http://homeassistant.local:8123/`
  --token YOUR_TOKEN # long lived Home Assistant token used for API calls
  --simulate # print light commands to stdout instead of sending them
- --verbose # print commands while also sending them
- --no-notify # disable Home Assistant persistent notifications on failures
- --program secondary # choose the light program to run (`default` or `secondary`)
- --port 8080 # port for the HTTP server (default 8080)
+--verbose # print commands while also sending them
+--no-notify # disable Home Assistant persistent notifications on failures
+--program secondary # choose the light program to run (`default` or `secondary`)
+--port 8080 # port for the HTTP server (default 8080)
 ```
+
+Light commands and errors are printed with ANSI colors when running in verbose
+or simulation mode to improve readability.
 
 The package builds on Linux and macOS. On macOS the POSIX server code uses the
 `Darwin` module, so the same command works there as well.

--- a/maestro/swift/Sources/Core/Logger.swift
+++ b/maestro/swift/Sources/Core/Logger.swift
@@ -1,12 +1,26 @@
 public struct Logger: @unchecked Sendable {
     let pusher: NotificationPusher?
 
+    enum Color {
+        static let red = "\u{001B}[31m"
+        static let cyan = "\u{001B}[36m"
+        static let reset = "\u{001B}[0m"
+    }
+
     public init(pusher: NotificationPusher?) {
         self.pusher = pusher
     }
 
+    private func colored(_ text: String, color: String) -> String {
+        return color + text + Color.reset
+    }
+
+    public func log(_ message: String) {
+        print(colored("[LOG] \(message)", color: Color.cyan))
+    }
+
     public func error(_ message: String) {
-        print("[ERROR] \(message)")
+        print(colored("[ERROR] \(message)", color: Color.red))
         pusher?.push(title: "Maestro Error", message: message)
     }
 }

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -32,7 +32,7 @@ public final class Maestro {
     /// If any step fails, the error is logged and the process stops.
     public func run() {
         if verbose {
-            logger.log("Running program \(program.name)")
+            logger.log("▶️ Running program \(program.name)")
         }
 
         let result = states.fetchAllStates()

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -32,7 +32,7 @@ public final class Maestro {
     /// If any step fails, the error is logged and the process stops.
     public func run() {
         if verbose {
-            print("[LOG] Running program \(program.name)")
+            logger.log("Running program \(program.name)")
         }
 
         let result = states.fetchAllStates()

--- a/maestro/swift/Sources/Core/MaestroFactory.swift
+++ b/maestro/swift/Sources/Core/MaestroFactory.swift
@@ -10,13 +10,13 @@ func makeMaestro(from options: MaestroOptions) -> Maestro {
 
     let lights: LightController
     if options.simulate {
-        lights = LoggingLightController()
+        lights = LoggingLightController(logger: logger)
     } else {
         let haLights = HomeAssistantLightController(baseURL: options.baseURL,
                                                    token: options.token,
                                                    logger: logger)
         lights = options.verbose ?
-            MultiLightController([haLights, LoggingLightController()]) :
+            MultiLightController([haLights, LoggingLightController(logger: logger)]) :
             haLights
     }
 

--- a/maestro/swift/Sources/Lights/LoggingLightController.swift
+++ b/maestro/swift/Sources/Lights/LoggingLightController.swift
@@ -3,10 +3,14 @@ import Foundation
 /// `LightController` implementation that prints light commands instead of
 /// sending them to Home Assistant. Useful for debugging.
 public final class LoggingLightController: LightController {
-    public init() {}
+    private let logger: Logger
+
+    public init(logger: Logger = Logger(pusher: nil)) {
+        self.logger = logger
+    }
 
     public func setLightState(state: LightState) {
-        var message = "[LOG] \(state.entityId) -> \(state.on ? "on" : "off")"
+        var message = "\(state.entityId) -> \(state.on ? "on" : "off")"
         if let b = state.brightness { message += " brightness:\(b)" }
         if let ct = state.colorTemperature { message += " colorTemp:\(ct)" }
         if let rgb = state.rgbColor {
@@ -17,14 +21,14 @@ public final class LoggingLightController: LightController {
         }
         if let effect = state.effect { message += " effect:\(effect)" }
         if let t = state.transitionDuration { message += " transition:\(t)" }
-        print(message)
+        logger.log(message)
     }
 
     public func stopAllDynamicScenes() {
-        print("[LOG] scene_presets.stop_all_dynamic_scenes")
+        logger.log("scene_presets.stop_all_dynamic_scenes")
     }
 
     public func setInputBoolean(entityId: String, to state: Bool) {
-        print("[LOG] \(entityId) -> \(state ? "on" : "off")")
+        logger.log("\(entityId) -> \(state ? "on" : "off")")
     }
 }


### PR DESCRIPTION
## Summary
- add ANSI color output to Logger
- show colored light commands in `LoggingLightController`
- wire up Logger in MaestroFactory
- use Logger for verbose mode
- document colored output in README

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6854f65f26508326a982958689ded412