### PR TITLE
Fix GPG failure on Swift workflow

### DIFF
--- a/.github/workflows/swift-tests.yaml
+++ b/.github/workflows/swift-tests.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+      - name: Import Swift signing keys
+        run: curl -sSL https://swift.org/keys/all-keys.asc | gpg --import -
       - name: Set up Swift
         uses: swift-actions/setup-swift@v2
         with:


### PR DESCRIPTION
## Summary
- import Swift signing keys before running setup-swift action

## Testing
- `swift test --package-path maestro/swift`

------
https://chatgpt.com/codex/tasks/task_e_6854f940f4fc8326a4e926b946f31d49