### PR TITLE
Add WLED main segment logic

### DIFF
--- a/Examples/wled_segment_automation.yaml
+++ b/Examples/wled_segment_automation.yaml
@@ -1,0 +1,18 @@
+# Example automation to keep WLED segment 0 (Main) at full brightness
+# when any TV shelf segment turns on
+alias: Ensure WLED main brightness
+mode: queued
+trigger:
+  - platform: state
+    entity_id:
+      - light.wled_tv_shelf_1
+      - light.wled_tv_shelf_2
+      - light.wled_tv_shelf_3
+      - light.wled_tv_shelf_4
+      - light.wled_tv_shelf_5
+    to: 'on'
+action:
+  - service: light.turn_on
+    data:
+      entity_id: light.wled_tv_shelf_main
+      brightness_pct: 100

--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ The maestro pipeline consists of 5 steps:
 5. **LIGHTS**: Applies the final computed states to the physical lights through the Home Assistant API (or simulates the changes if in simulation mode).
 
 This pipeline runs each time the `/run` endpoint is called, ensuring the lights always match the desired state based on current conditions.
+
+## Example: WLED Segment Automation
+
+See `Examples/wled_segment_automation.yaml` for a Home Assistant automation that
+keeps the WLED "Main" segment at full brightness whenever any of the TV shelf
+segments are switched on.

--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -55,7 +55,8 @@ public struct LightProgramDefault: LightProgram {
         var changes = baseSceneChanges(scene: scene, environment: environment)
         applyKitchenSink(scene: scene, environment: environment, changes: &changes)
         let expanded = expandTvShelfGroup(changes: changes, environment: environment, transition: transition)
-        return scaleBrightness(changes: expanded, states: states, transition: transition)
+        let scaled = scaleBrightness(changes: expanded, states: states, transition: transition)
+        return ensureWledMain(changes: scaled, transition: transition)
     }
 
     private func baseSceneChanges(scene: StateContext.Scene, environment: StateContext.Environment) -> [LightState] {
@@ -237,6 +238,24 @@ public struct LightProgramDefault: LightProgram {
                               effect: state.effect,
                               transitionDuration: transition)
         }
+    }
+
+    private func ensureWledMain(changes: [LightState],
+                                transition: Double) -> [LightState] {
+        let mainId = "light.wled_tv_shelf_main"
+        let hasShelfOn = changes.contains { state in
+            state.entityId.hasPrefix("light.wled_tv_shelf_") &&
+            state.entityId != mainId &&
+            state.on
+        }
+        var filtered = changes.filter { $0.entityId != mainId }
+        if hasShelfOn {
+            filtered.append(LightState(entityId: mainId,
+                                      on: true,
+                                      brightness: 100,
+                                      transitionDuration: transition))
+        }
+        return filtered
     }
 
     private func blendStates(from pre: [LightState],

--- a/maestro/swift/Tests/maestroTests/LightProgramDefaultTests.swift
+++ b/maestro/swift/Tests/maestroTests/LightProgramDefaultTests.swift
@@ -185,4 +185,20 @@ final class LightProgramDefaultTests: XCTestCase {
         XCTAssertEqual(tvLight?.colorTemperature, 309)
         XCTAssertEqual(tvLight?.transitionDuration, 2)
     }
+
+    func testMainSegmentOnWhenShelfOn() {
+        let context = StateContext(states: [
+            "input_select.living_scene": ["state": "bright"],
+            "binary_sensor.living_tv_hyperion_running_condition_for_the_scene": ["state": "off"],
+            "binary_sensor.dining_espresence": ["state": "off"],
+            "binary_sensor.kitchen_espresence": ["state": "off"],
+            "binary_sensor.kitchen_presence_occupancy": ["state": "off"],
+            "input_boolean.kitchen_extra_brightness": ["state": "off"]
+        ])
+
+        let diff = LightProgramDefault().computeStateSet(context: context)
+        let main = diff.desiredStates.first { $0.entityId == "light.wled_tv_shelf_main" }
+        XCTAssertEqual(main?.brightness, 100)
+        XCTAssertTrue(main?.on ?? false)
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the WLED main segment turns on at full brightness whenever any TV shelf segment is on
- add regression test for this behavior

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68559a7721708326992c57df51f784d5