### PR TITLE
Improve logging with timestamp and context info

### DIFF
--- a/maestro/swift/Sources/Context/StateContext+Description.swift
+++ b/maestro/swift/Sources/Context/StateContext+Description.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension StateContext: CustomStringConvertible {
+    public var description: String {
+        let sceneName = String(describing: scene)
+        let progress = String(format: "%.2f", environment.sunsetProgress)
+        return "scene: \(sceneName) sunset: \(progress)"
+    }
+}

--- a/maestro/swift/Sources/Core/Logger.swift
+++ b/maestro/swift/Sources/Core/Logger.swift
@@ -1,5 +1,12 @@
+import Foundation
+
 public struct Logger: @unchecked Sendable {
     let pusher: NotificationPusher?
+    private static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 
     enum Color {
         static let red = "\u{001B}[31m"
@@ -16,11 +23,13 @@ public struct Logger: @unchecked Sendable {
     }
 
     public func log(_ message: String) {
-        print(colored("[LOG] \(message)", color: Color.cyan))
+        let ts = Logger.formatter.string(from: Date())
+        print(colored("[\(ts)] [LOG] \(message)", color: Color.cyan))
     }
 
     public func error(_ message: String) {
-        print(colored("[ERROR] \(message)", color: Color.red))
+        let ts = Logger.formatter.string(from: Date())
+        print(colored("[\(ts)] [ERROR] \(message)", color: Color.red))
         pusher?.push(title: "Maestro Error", message: message)
     }
 }

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -39,6 +39,9 @@ public final class Maestro {
         switch result {
         case .success(let states):
             let context = StateContext(states: states)
+            if verbose {
+                logger.log(context.description)
+            }
             let output = program.compute(context: context)
             let lightEffects = output.changeset.simplified.map { SideEffect.setLight($0) }
             let allEffects = output.sideEffects + lightEffects

--- a/maestro/swift/Tests/maestroTests/StateContextDescriptionTests.swift
+++ b/maestro/swift/Tests/maestroTests/StateContextDescriptionTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import maestro
+
+final class StateContextDescriptionTests: XCTestCase {
+    func testDescriptionShowsSceneAndSunsetProgress() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let nextSetting = formatter.string(from: Date().addingTimeInterval(30 * 60))
+        let context = StateContext(states: [
+            "input_select.living_scene": ["state": "normal"],
+            "sun.sun": ["state": "above_horizon", "attributes": ["next_setting": nextSetting]]
+        ])
+        XCTAssertEqual(context.description, "scene: normal sunset: 0.50")
+    }
+}


### PR DESCRIPTION
## Summary
- add ISO formatted timestamp for each log line
- show scene and sunset progress when running program
- use `StateContext.description` when logging verbose info

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6855ae5ab1c483268b42623e0a844974