### PR TITLE
Implement step-based side effects

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,6 +111,8 @@ Feature 4 of the roadmap calls for more refined time-of-day logic within the Swi
 
 These actions are all side effects of deciding what the lights should do. Because they're executed directly, any new behaviour would further crowd `Maestro.run()` with additional service calls. A more maintainable approach is to collect all side effects during the PROGRAM step (lights, helper booleans, scene preset commands, logs, etc.) and execute them in the final LIGHTS step. This keeps decision making separate from performing the actions and declutters the core loop.
 
+See [docs/side-effects.md](side-effects.md) for details on the chosen approach.
+
 ## Implementation Strategy
 
 1. Start with Quick Wins to build momentum and improve usability

--- a/docs/side-effects.md
+++ b/docs/side-effects.md
@@ -1,0 +1,5 @@
+# Collecting Side Effects
+
+Maestro separates decision making from performing actions. During the PROGRAM step each `ProgramStep` may append side effects that should happen later. A side effect is anything other than returning the final light state (for example updating helper booleans or stopping dynamic scenes).
+
+`ProgramStep.apply` returns `(changes: [LightState], effects: [SideEffect])`. The pipeline passes the current lists to each step so it can append new effects without modifying earlier ones. After every step has run, `LightProgram.compute` executes the gathered effects followed by the light updates.

--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -21,16 +21,35 @@ public struct LightProgramDefault: LightProgram {
     }
 
     public func compute(context: StateContext) -> ProgramOutput {
-        var sideEffects: [SideEffect] = []
+        let states = context.states
+        let transition = 2.0
+
+        var changes: [LightState] = []
+        var effects: [SideEffect] = []
+
         if !context.environment.kitchenPresence {
-            sideEffects.append(.setInputBoolean(entityId: "input_boolean.kitchen_extra_brightness", state: false))
+            effects.append(.setInputBoolean(entityId: "input_boolean.kitchen_extra_brightness", state: false))
         }
         if context.environment.autoMode && context.scene != .preset {
-            sideEffects.append(.stopAllDynamicScenes)
+            effects.append(.stopAllDynamicScenes)
         }
 
-        let changeset = computeStateSet(context: context)
-        return ProgramOutput(changeset: changeset, sideEffects: sideEffects)
+        guard context.environment.autoMode else {
+            return ProgramOutput(changeset: LightStateChangeset(currentStates: states, desiredStates: []),
+                                 sideEffects: effects)
+        }
+
+        for step in steps {
+            let result = step.apply(changes: changes,
+                                    effects: effects,
+                                    context: context,
+                                    transition: transition)
+            changes = result.0
+            effects = result.1
+        }
+
+        let changeset = LightStateChangeset(currentStates: states, desiredStates: changes)
+        return ProgramOutput(changeset: changeset, sideEffects: effects)
     }
 
     // Original method preserved for direct tests
@@ -43,247 +62,15 @@ public struct LightProgramDefault: LightProgram {
         }
 
         var changes: [LightState] = []
+        var effects: [SideEffect] = []
         for step in steps {
-            changes = step.apply(changes: changes, context: context, transition: transition)
+            let result = step.apply(changes: changes,
+                                    effects: effects,
+                                    context: context,
+                                    transition: transition)
+            changes = result.0
+            effects = result.1
         }
         return LightStateChangeset(currentStates: states, desiredStates: changes)
-    }
-}
-
-// MARK: - Pipeline Steps
-
-struct BaseSceneStep: ProgramStep {
-    let name = "baseScene"
-
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState] {
-        var changes = changes
-        changes = sceneChanges(scene: context.scene, environment: context.environment)
-        return changes
-    }
-
-    private func sceneChanges(scene: StateContext.Scene, environment: StateContext.Environment) -> [LightState] {
-        var changes: [LightState] = []
-
-        switch scene {
-        case .off:
-            changes.off(["light.living_temperature_lights", "light.color_lights", "light.window_led_strip", "light.kitchen_led"])
-
-        case .calmNight:
-            if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
-                changes.on("light.kitchen_led", brightness: 50, effect: "solid")
-                changes.on("light.tripod_lamp", brightness: 10, colorTemperature: 200)
-            } else {
-                if !environment.hyperionRunning {
-                    changes.on("light.tv_shelf_group", brightness: 2, effect: "solid")
-                } else {
-                    changes.off("light.tv_shelf_group")
-                }
-                changes.on("light.window_led_strip", brightness: 17, effect: "solid")
-                changes.on(["light.entrance_dining_light", "light.living_entry_door_light", "light.living_fireplace_spot"], brightness: 10)
-                changes.on("light.desk_light", brightness: 5)
-                changes.off(["light.shoes_light", "light.tv_light", "light.chaise_light", "light.corredor_door_light"])
-                changes.on("light.tripod_lamp", brightness: 10)
-                changes.on("light.zigbee_hub_estante_lights", brightness: 8)
-                changes.on("light.living_art_wall_light", brightness: 10)
-                changes.on("light.kitchen_led", brightness: 50, effect: "solid")
-                if environment.diningPresence {
-                    changes.on("light.dining_table_light", brightness: 30)
-                } else {
-                    changes.on("light.dining_table_light", brightness: 10)
-                }
-            }
-
-        case .normal:
-            if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
-                if !environment.hyperionRunning {
-                    changes.on("light.tv_light", brightness: 50, colorTemperature: 224)
-                    changes.on("light.wled_tv_shelf_4", brightness: 20, rgbwColor: (7, 106, 168, 255), effect: "solid")
-                } else {
-                    changes.off(["light.tv_light", "light.tv_shelf_group"])
-                }
-                changes.on("light.dining_table_light", brightness: 100, colorTemperature: 206)
-                changes.off("light.corner_light")
-                changes.on("light.desk_light", brightness: 40, colorTemperature: 199)
-                changes.on(["light.corredor_door_light", "light.entrance_dining_light", "light.living_entry_door_light"], brightness: 60, colorTemperature: 250)
-                changes.on("light.shoes_light", brightness: 50, colorTemperature: 250)
-                changes.off(["light.chaise_light", "light.window_led_strip"])
-                changes.on("light.living_art_wall_light", brightness: 60, colorTemperature: 196)
-                changes.on("light.tripod_lamp", brightness: 49, colorTemperature: 206)
-                changes.off("light.living_fireplace_spot")
-                changes.on("light.zigbee_hub_estante_lights", brightness: 55, colorTemperature: 198)
-                changes.on("light.kitchen_led", brightness: 50, rgbwColor: (0, 0, 0, 255), effect: "solid")
-            } else {
-                if !environment.hyperionRunning {
-                    changes.on("light.tv_light", brightness: 51, colorTemperature: 394)
-                    changes.on("light.tv_shelf_group", brightness: 20, rgbwColor: (255, 158, 64, 255), effect: "solid")
-                } else {
-                    changes.off("light.tv_light")
-                }
-                changes.on("light.color_lights_without_tv_light", brightness: 51, colorTemperature: 394)
-                changes.on("light.corner_light", brightness: 30, colorTemperature: 394)
-                changes.on("light.window_led_strip", brightness: 40, rgbColor: (189, 157, 112), effect: "solid")
-                changes.on(["light.living_fireplace_spot", "light.living_entry_door_light", "light.shoes_light", "light.entrance_dining_light", "light.corredor_door_light"], brightness: 20, colorTemperature: 404)
-                changes.off("light.chaise_light")
-                changes.on("light.kitchen_led", brightness: 26, rgbwColor: (230, 170, 30, 150), effect: "solid")
-            }
-
-        case .bright:
-            if !environment.hyperionRunning {
-                changes.on("light.tv_light", brightness: 75)
-                changes.on("light.tv_shelf_group", brightness: 100, effect: "solid")
-            } else {
-                changes.off(["light.tv_light", "light.tv_shelf_group"])
-            }
-            changes.on("light.living_temperature_lights", brightness: 60)
-            changes.on("light.color_lights_without_tv_light", brightness: 75)
-            changes.on("light.window_led_strip", brightness: 100, effect: "solid")
-            changes.on("light.zigbee_hub_estante_lights", brightness: 75)
-            changes.on("light.kitchen_led", brightness: 100, effect: "solid")
-
-        case .brightest:
-            if !environment.hyperionRunning {
-                changes.on("light.tv_light", brightness: 100)
-                changes.on("light.tv_shelf_group", brightness: 100, effect: "solid")
-            } else {
-                changes.off(["light.tv_light", "light.tv_shelf_group"])
-            }
-            changes.on(["light.living_temperature_lights", "light.color_lights_without_tv_light", "light.window_led_strip", "light.zigbee_hub_estante_lights", "light.kitchen_led"], brightness: 100)
-
-        case .preset:
-            changes.off("light.living_temperature_lights")
-        }
-
-        return changes
-    }
-}
-
-struct KitchenSinkStep: ProgramStep {
-    let name = "kitchenSink"
-
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState] {
-        var changes = changes
-        applyKitchenSink(scene: context.scene, environment: context.environment, changes: &changes)
-        return changes
-    }
-
-    private func applyKitchenSink(scene: StateContext.Scene, environment: StateContext.Environment, changes: inout [LightState]) {
-        let sinkColor: (Int, Int, Int, Int)
-        if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
-            sinkColor = (0, 0, 0, 255)
-        } else {
-            sinkColor = (230, 170, 30, 150)
-        }
-        let kitchenOnBrightness: Int
-        if environment.kitchenPresence {
-            if (scene == .calmNight || scene == .normal || scene == .off) && !environment.kitchenExtraBrightness {
-                kitchenOnBrightness = 60
-            } else {
-                kitchenOnBrightness = 100
-            }
-            changes.on("light.kitchen_sink_light", brightness: kitchenOnBrightness, rgbwColor: sinkColor, effect: "solid")
-            changes.on("light.kitchen_sink_light_old", brightness: 20)
-        } else if scene != .off {
-            changes.on("light.kitchen_sink_light", brightness: 10, rgbwColor: sinkColor, effect: "solid")
-            changes.on("light.kitchen_sink_light_old", brightness: 10)
-        }
-    }
-}
-
-struct TvShelfGroupStep: ProgramStep {
-    let name = "tvShelfGroup"
-
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState] {
-        expandTvShelfGroup(changes: changes, environment: context.environment, transition: transition)
-    }
-
-    private func expandTvShelfGroup(changes: [LightState], environment: StateContext.Environment, transition: Double) -> [LightState] {
-        var expanded: [LightState] = []
-        let shelfIds = (1...5).map { "light.wled_tv_shelf_\($0)" }
-        for state in changes {
-            if state.entityId == "light.tv_shelf_group" {
-                var group = LightGroup.group(
-                    Dictionary(uniqueKeysWithValues: shelfIds.map { id in
-                        (id, LightGroup.light(LightState(entityId: id, on: false)))
-                    })
-                )
-                for (index, id) in shelfIds.enumerated() {
-                    let enabled = environment.tvShelvesEnabled[index]
-                    let shelfState: LightState
-                    if enabled {
-                        shelfState = LightState(entityId: id,
-                                               on: state.on,
-                                               brightness: state.brightness,
-                                               colorTemperature: state.colorTemperature,
-                                               rgbColor: state.rgbColor,
-                                               rgbwColor: state.rgbwColor,
-                                               effect: state.effect,
-                                               transitionDuration: transition)
-                    } else {
-                        shelfState = LightState(entityId: id,
-                                               on: false,
-                                               transitionDuration: transition)
-                    }
-                    group.update(entityId: id, with: shelfState)
-                }
-                expanded.append(contentsOf: group.flattened())
-            } else {
-                expanded.append(state)
-            }
-        }
-        return expanded
-    }
-}
-
-struct GlobalBrightnessStep: ProgramStep {
-    let name = "globalBrightness"
-
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState] {
-        scaleBrightness(changes: changes, states: context.states, transition: transition)
-    }
-
-    private func scaleBrightness(changes: [LightState], states: HomeAssistantStateMap, transition: Double) -> [LightState] {
-        let scaleStr = states["input_number.living_scene_brightness_percentage"]?["state"] as? String ?? "100"
-        let scalePct = Double(scaleStr) ?? 100
-        let scale = max(0.0, min(scalePct, 100.0)) / 100.0
-        return changes.map { state -> LightState in
-            var brightness = state.brightness
-            if let b = state.brightness {
-                let scaled = Int(round(Double(b) * scale))
-                brightness = max(1, min(100, scaled))
-            }
-            return LightState(entityId: state.entityId,
-                              on: state.on,
-                              brightness: brightness,
-                              colorTemperature: state.colorTemperature,
-                              rgbColor: state.rgbColor,
-                              rgbwColor: state.rgbwColor,
-                              effect: state.effect,
-                              transitionDuration: transition)
-        }
-    }
-}
-
-struct WledMainStep: ProgramStep {
-    let name = "wledMain"
-
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState] {
-        ensureWledMain(changes: changes, transition: transition)
-    }
-
-    private func ensureWledMain(changes: [LightState], transition: Double) -> [LightState] {
-        let mainId = "light.wled_tv_shelf_main"
-        let hasShelfOn = changes.contains { state in
-            state.entityId.hasPrefix("light.wled_tv_shelf_") &&
-            state.entityId != mainId &&
-            state.on
-        }
-        var filtered = changes.filter { $0.entityId != mainId }
-        if hasShelfOn {
-            filtered.append(LightState(entityId: mainId,
-                                      on: true,
-                                      brightness: 100,
-                                      transitionDuration: transition))
-        }
-        return filtered
     }
 }

--- a/maestro/swift/Sources/Programs/ProgramStep.swift
+++ b/maestro/swift/Sources/Programs/ProgramStep.swift
@@ -1,4 +1,4 @@
 public protocol ProgramStep {
     var name: String { get }
-    func apply(changes: [LightState], context: StateContext, transition: Double) -> [LightState]
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect])
 }

--- a/maestro/swift/Sources/Programs/Steps/BaseSceneStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/BaseSceneStep.swift
@@ -1,0 +1,104 @@
+struct BaseSceneStep: ProgramStep {
+    let name = "baseScene"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        var changes = changes
+        changes = sceneChanges(scene: context.scene, environment: context.environment)
+        return (changes, effects)
+    }
+
+    private func sceneChanges(scene: StateContext.Scene, environment: StateContext.Environment) -> [LightState] {
+        var changes: [LightState] = []
+
+        switch scene {
+        case .off:
+            changes.off(["light.living_temperature_lights", "light.color_lights", "light.window_led_strip", "light.kitchen_led"])
+
+        case .calmNight:
+            if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
+                changes.on("light.kitchen_led", brightness: 50, effect: "solid")
+                changes.on("light.tripod_lamp", brightness: 10, colorTemperature: 200)
+            } else {
+                if !environment.hyperionRunning {
+                    changes.on("light.tv_shelf_group", brightness: 2, effect: "solid")
+                } else {
+                    changes.off("light.tv_shelf_group")
+                }
+                changes.on("light.window_led_strip", brightness: 17, effect: "solid")
+                changes.on(["light.entrance_dining_light", "light.living_entry_door_light", "light.living_fireplace_spot"], brightness: 10)
+                changes.on("light.desk_light", brightness: 5)
+                changes.off(["light.shoes_light", "light.tv_light", "light.chaise_light", "light.corredor_door_light"])
+                changes.on("light.tripod_lamp", brightness: 10)
+                changes.on("light.zigbee_hub_estante_lights", brightness: 8)
+                changes.on("light.living_art_wall_light", brightness: 10)
+                changes.on("light.kitchen_led", brightness: 50, effect: "solid")
+                if environment.diningPresence {
+                    changes.on("light.dining_table_light", brightness: 30)
+                } else {
+                    changes.on("light.dining_table_light", brightness: 10)
+                }
+            }
+
+        case .normal:
+            if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
+                if !environment.hyperionRunning {
+                    changes.on("light.tv_light", brightness: 50, colorTemperature: 224)
+                    changes.on("light.wled_tv_shelf_4", brightness: 20, rgbwColor: (7, 106, 168, 255), effect: "solid")
+                } else {
+                    changes.off(["light.tv_light", "light.tv_shelf_group"])
+                }
+                changes.on("light.dining_table_light", brightness: 100, colorTemperature: 206)
+                changes.off("light.corner_light")
+                changes.on("light.desk_light", brightness: 40, colorTemperature: 199)
+                changes.on(["light.corredor_door_light", "light.entrance_dining_light", "light.living_entry_door_light"], brightness: 60, colorTemperature: 250)
+                changes.on("light.shoes_light", brightness: 50, colorTemperature: 250)
+                changes.off(["light.chaise_light", "light.window_led_strip"])
+                changes.on("light.living_art_wall_light", brightness: 60, colorTemperature: 196)
+                changes.on("light.tripod_lamp", brightness: 49, colorTemperature: 206)
+                changes.off("light.living_fireplace_spot")
+                changes.on("light.zigbee_hub_estante_lights", brightness: 55, colorTemperature: 198)
+                changes.on("light.kitchen_led", brightness: 50, rgbwColor: (0, 0, 0, 255), effect: "solid")
+            } else {
+                if !environment.hyperionRunning {
+                    changes.on("light.tv_light", brightness: 51, colorTemperature: 394)
+                    changes.on("light.tv_shelf_group", brightness: 20, rgbwColor: (255, 158, 64, 255), effect: "solid")
+                } else {
+                    changes.off("light.tv_light")
+                }
+                changes.on("light.color_lights_without_tv_light", brightness: 51, colorTemperature: 394)
+                changes.on("light.corner_light", brightness: 30, colorTemperature: 394)
+                changes.on("light.window_led_strip", brightness: 40, rgbColor: (189, 157, 112), effect: "solid")
+                changes.on(["light.living_fireplace_spot", "light.living_entry_door_light", "light.shoes_light", "light.entrance_dining_light", "light.corredor_door_light"], brightness: 20, colorTemperature: 404)
+                changes.off("light.chaise_light")
+                changes.on("light.kitchen_led", brightness: 26, rgbwColor: (230, 170, 30, 150), effect: "solid")
+            }
+
+        case .bright:
+            if !environment.hyperionRunning {
+                changes.on("light.tv_light", brightness: 75)
+                changes.on("light.tv_shelf_group", brightness: 100, effect: "solid")
+            } else {
+                changes.off(["light.tv_light", "light.tv_shelf_group"])
+            }
+            changes.on("light.living_temperature_lights", brightness: 60)
+            changes.on("light.color_lights_without_tv_light", brightness: 75)
+            changes.on("light.window_led_strip", brightness: 100, effect: "solid")
+            changes.on("light.zigbee_hub_estante_lights", brightness: 75)
+            changes.on("light.kitchen_led", brightness: 100, effect: "solid")
+
+        case .brightest:
+            if !environment.hyperionRunning {
+                changes.on("light.tv_light", brightness: 100)
+                changes.on("light.tv_shelf_group", brightness: 100, effect: "solid")
+            } else {
+                changes.off(["light.tv_light", "light.tv_shelf_group"])
+            }
+            changes.on(["light.living_temperature_lights", "light.color_lights_without_tv_light", "light.window_led_strip", "light.zigbee_hub_estante_lights", "light.kitchen_led"], brightness: 100)
+
+        case .preset:
+            changes.off("light.living_temperature_lights")
+        }
+
+        return changes
+    }
+}

--- a/maestro/swift/Sources/Programs/Steps/GlobalBrightnessStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/GlobalBrightnessStep.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct GlobalBrightnessStep: ProgramStep {
+    let name = "globalBrightness"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        let adjusted = scaleBrightness(changes: changes, states: context.states, transition: transition)
+        return (adjusted, effects)
+    }
+
+    private func scaleBrightness(changes: [LightState], states: HomeAssistantStateMap, transition: Double) -> [LightState] {
+        let scaleStr = states["input_number.living_scene_brightness_percentage"]?["state"] as? String ?? "100"
+        let scalePct = Double(scaleStr) ?? 100
+        let scale = max(0.0, min(scalePct, 100.0)) / 100.0
+        return changes.map { state -> LightState in
+            var brightness = state.brightness
+            if let b = state.brightness {
+                let scaled = Int(round(Double(b) * scale))
+                brightness = max(1, min(100, scaled))
+            }
+            return LightState(entityId: state.entityId,
+                              on: state.on,
+                              brightness: brightness,
+                              colorTemperature: state.colorTemperature,
+                              rgbColor: state.rgbColor,
+                              rgbwColor: state.rgbwColor,
+                              effect: state.effect,
+                              transitionDuration: transition)
+        }
+    }
+}

--- a/maestro/swift/Sources/Programs/Steps/KitchenSinkStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/KitchenSinkStep.swift
@@ -1,0 +1,31 @@
+struct KitchenSinkStep: ProgramStep {
+    let name = "kitchenSink"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        var changes = changes
+        applyKitchenSink(scene: context.scene, environment: context.environment, changes: &changes)
+        return (changes, effects)
+    }
+
+    private func applyKitchenSink(scene: StateContext.Scene, environment: StateContext.Environment, changes: inout [LightState]) {
+        let sinkColor: (Int, Int, Int, Int)
+        if environment.timeOfDay == .daytime || environment.timeOfDay == .preSunset {
+            sinkColor = (0, 0, 0, 255)
+        } else {
+            sinkColor = (230, 170, 30, 150)
+        }
+        let kitchenOnBrightness: Int
+        if environment.kitchenPresence {
+            if (scene == .calmNight || scene == .normal || scene == .off) && !environment.kitchenExtraBrightness {
+                kitchenOnBrightness = 60
+            } else {
+                kitchenOnBrightness = 100
+            }
+            changes.on("light.kitchen_sink_light", brightness: kitchenOnBrightness, rgbwColor: sinkColor, effect: "solid")
+            changes.on("light.kitchen_sink_light_old", brightness: 20)
+        } else if scene != .off {
+            changes.on("light.kitchen_sink_light", brightness: 10, rgbwColor: sinkColor, effect: "solid")
+            changes.on("light.kitchen_sink_light_old", brightness: 10)
+        }
+    }
+}

--- a/maestro/swift/Sources/Programs/Steps/TvShelfGroupStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/TvShelfGroupStep.swift
@@ -1,0 +1,45 @@
+struct TvShelfGroupStep: ProgramStep {
+    let name = "tvShelfGroup"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        let result = expandTvShelfGroup(changes: changes, environment: context.environment, transition: transition)
+        return (result, effects)
+    }
+
+    private func expandTvShelfGroup(changes: [LightState], environment: StateContext.Environment, transition: Double) -> [LightState] {
+        var expanded: [LightState] = []
+        let shelfIds = (1...5).map { "light.wled_tv_shelf_\($0)" }
+        for state in changes {
+            if state.entityId == "light.tv_shelf_group" {
+                var group = LightGroup.group(
+                    Dictionary(uniqueKeysWithValues: shelfIds.map { id in
+                        (id, LightGroup.light(LightState(entityId: id, on: false)))
+                    })
+                )
+                for (index, id) in shelfIds.enumerated() {
+                    let enabled = environment.tvShelvesEnabled[index]
+                    let shelfState: LightState
+                    if enabled {
+                        shelfState = LightState(entityId: id,
+                                               on: state.on,
+                                               brightness: state.brightness,
+                                               colorTemperature: state.colorTemperature,
+                                               rgbColor: state.rgbColor,
+                                               rgbwColor: state.rgbwColor,
+                                               effect: state.effect,
+                                               transitionDuration: transition)
+                    } else {
+                        shelfState = LightState(entityId: id,
+                                               on: false,
+                                               transitionDuration: transition)
+                    }
+                    group.update(entityId: id, with: shelfState)
+                }
+                expanded.append(contentsOf: group.flattened())
+            } else {
+                expanded.append(state)
+            }
+        }
+        return expanded
+    }
+}

--- a/maestro/swift/Sources/Programs/Steps/WledMainStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/WledMainStep.swift
@@ -1,0 +1,25 @@
+struct WledMainStep: ProgramStep {
+    let name = "wledMain"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        let result = ensureWledMain(changes: changes, transition: transition)
+        return (result, effects)
+    }
+
+    private func ensureWledMain(changes: [LightState], transition: Double) -> [LightState] {
+        let mainId = "light.wled_tv_shelf_main"
+        let hasShelfOn = changes.contains { state in
+            state.entityId.hasPrefix("light.wled_tv_shelf_") &&
+            state.entityId != mainId &&
+            state.on
+        }
+        var filtered = changes.filter { $0.entityId != mainId }
+        if hasShelfOn {
+            filtered.append(LightState(entityId: mainId,
+                                      on: true,
+                                      brightness: 100,
+                                      transitionDuration: transition))
+        }
+        return filtered
+    }
+}


### PR DESCRIPTION
## Summary
- describe the side-effects design in `docs/side-effects.md`
- implement side effects accumulation across program steps
- split program steps into their own files
- update roadmap link

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68571d76b8408326b9d17fdbf6bba6f8