### PR TITLE
Unify compute method

### DIFF
--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -51,26 +51,4 @@ public struct LightProgramDefault: LightProgram {
         let changeset = LightStateChangeset(currentStates: states, desiredStates: changes)
         return ProgramOutput(changeset: changeset, sideEffects: effects)
     }
-
-    // Original method preserved for direct tests
-    public func computeStateSet(context: StateContext) -> LightStateChangeset {
-        let states = context.states
-        let transition = 2.0
-
-        guard context.environment.autoMode else {
-            return LightStateChangeset(currentStates: states, desiredStates: [])
-        }
-
-        var changes: [LightState] = []
-        var effects: [SideEffect] = []
-        for step in steps {
-            let result = step.apply(changes: changes,
-                                    effects: effects,
-                                    context: context,
-                                    transition: transition)
-            changes = result.0
-            effects = result.1
-        }
-        return LightStateChangeset(currentStates: states, desiredStates: changes)
-    }
 }

--- a/maestro/swift/Tests/maestroTests/LightProgramDefaultTests.swift
+++ b/maestro/swift/Tests/maestroTests/LightProgramDefaultTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class LightProgramDefaultTests: XCTestCase {
     func testOffSceneTurnsAllLightsOff() {
         let context = StateContext(states: ["input_select.living_scene": ["state": "off"]])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         
         // Verify all lights are turned off
         for lightState in diff.desiredStates {
@@ -21,7 +21,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "binary_sensor.kitchen_espresence": ["state": "off"],
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         
         let tvLight = diff.desiredStates.first { $0.entityId == "light.tv_light" }
         XCTAssertFalse(tvLight?.on ?? true)
@@ -42,7 +42,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "binary_sensor.kitchen_espresence": ["state": "off"],
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         
         let tvLight = diff.desiredStates.first { $0.entityId == "light.tv_light" }
         XCTAssertFalse(tvLight?.on ?? true)
@@ -66,8 +66,8 @@ final class LightProgramDefaultTests: XCTestCase {
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
         
-        let diffWithPresence = LightProgramDefault().computeStateSet(context: contextWithPresence)
-        let diffWithoutPresence = LightProgramDefault().computeStateSet(context: contextWithoutPresence)
+        let diffWithPresence = LightProgramDefault().compute(context: contextWithPresence).changeset
+        let diffWithoutPresence = LightProgramDefault().compute(context: contextWithoutPresence).changeset
         
         // dining table brighter when presence detected
         let diningWithPresence = diffWithPresence.desiredStates.first { $0.entityId == "light.dining_table_light" }
@@ -80,7 +80,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "input_select.living_scene": ["state": "normal"],
             "input_boolean.living_scene_auto": ["state": "off"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         XCTAssertTrue(diff.desiredStates.isEmpty)
     }
 
@@ -91,7 +91,7 @@ final class LightProgramDefaultTests: XCTestCase {
                                           "binary_sensor.dining_espresence": ["state": "off"],
                                           "binary_sensor.kitchen_espresence": ["state": "off"],
                                           "input_boolean.kitchen_extra_brightness": ["state": "off"]])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         for state in diff.desiredStates {
             XCTAssertEqual(state.transitionDuration, 2, "Expected transition of 2 seconds")
         }
@@ -111,7 +111,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "input_boolean.wled_tv_shelf_4": ["state": "on"],
             "input_boolean.wled_tv_shelf_5": ["state": "on"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
 
         let shelf2 = diff.desiredStates.first { $0.entityId == "light.wled_tv_shelf_2" }
         XCTAssertFalse(shelf2?.on ?? true)
@@ -130,7 +130,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "binary_sensor.kitchen_presence_occupancy": ["state": "on"],
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         let sink = diff.desiredStates.first { $0.entityId == "light.kitchen_sink_light" }
         XCTAssertEqual(sink?.brightness, 60)
         XCTAssertEqual(sink?.rgbwColor?.3, 255)
@@ -145,7 +145,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "binary_sensor.kitchen_espresence": ["state": "on"],
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         let sink = diff.desiredStates.first { $0.entityId == "light.kitchen_sink_light" }
         XCTAssertEqual(sink?.rgbwColor?.0, 230)
         XCTAssertEqual(sink?.rgbwColor?.1, 170)
@@ -162,7 +162,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "binary_sensor.kitchen_espresence": ["state": "off"],
             "input_boolean.kitchen_extra_brightness": ["state": "on"]
         ])
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         let sink = diff.desiredStates.first { $0.entityId == "light.kitchen_sink_light" }
         XCTAssertEqual(sink?.brightness, 10)
     }
@@ -177,7 +177,7 @@ final class LightProgramDefaultTests: XCTestCase {
             "input_boolean.kitchen_extra_brightness": ["state": "off"]
         ])
 
-        let diff = LightProgramDefault().computeStateSet(context: context)
+        let diff = LightProgramDefault().compute(context: context).changeset
         let main = diff.desiredStates.first { $0.entityId == "light.wled_tv_shelf_main" }
         XCTAssertEqual(main?.brightness, 100)
         XCTAssertTrue(main?.on ?? false)

--- a/maestro/swift/Tests/maestroTests/MaestroDynamicScenesTests.swift
+++ b/maestro/swift/Tests/maestroTests/MaestroDynamicScenesTests.swift
@@ -30,8 +30,6 @@ final class MaestroDynamicScenesTests: XCTestCase {
             }
             return ProgramOutput(changeset: LightStateChangeset(currentStates: context.states, desiredStates: []), sideEffects: effects)
         }
-        // maintain old method for convenience
-        func computeStateSet(context: StateContext) -> LightStateChangeset { .init(currentStates: context.states, desiredStates: []) }
     }
 
     func testStopsDynamicScenesWhenNotPreset() {


### PR DESCRIPTION
## Summary
- drop `computeStateSet` and fold logic into `compute`
- adapt tests to use the unified method

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_685723bfce0483268013be952dc050fe