### PR TITLE
Rename LightController to EffectController

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ The original Home Assistant Python automation includes a variety of capabilities
 
 ### 3. Transition Support *(implemented)*
 - Add transition duration field to `LightState`
-- Update `LightController` implementations to handle transitions
+- Update `EffectController` implementations to handle transitions
 - Implement 2-second fade support for relevant actions
 
 ### 4. Advanced Time-of-Day Handling *(implemented)*
@@ -72,12 +72,12 @@ Feature 4 of the roadmap calls for more refined time-of-day logic within the Swi
   - `rgb_color`
   - `rgbw_color`
 - Update `LightStateChangeset` to compare color values
-- Modify light controller implementations accordingly
+- Modify effect controller implementations accordingly
 
 ### 6.2. Effects (implemented)
 - Extend `LightState` to support `effect` values
 - Update `LightStateChangeset` to compare effect values
-- Modify light controller implementations accordingly
+- Modify effect controller implementations accordingly
 - In the original Python automation, WLED strips were always sent
   `effect: "solid"` whenever turned on. Without this, the lights might resume
   whatever dynamic effect was previously active. The comparison should ignore

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -2,13 +2,13 @@ import Foundation
 
 public final class Maestro {
     private let states: StateProvider
-    private let lights: LightController
+    private let lights: EffectController
     private let program: LightProgram
     private let logger: Logger
     private let verbose: Bool
 
     public init(states: StateProvider,
-                lights: LightController,
+                lights: EffectController,
                 program: LightProgram,
                 logger: Logger,
                 verbose: Bool = false) {

--- a/maestro/swift/Sources/Core/MaestroFactory.swift
+++ b/maestro/swift/Sources/Core/MaestroFactory.swift
@@ -8,15 +8,15 @@ func makeMaestro(from options: MaestroOptions) -> Maestro {
 
     let states = HomeAssistantStateProvider(baseURL: options.baseURL, token: options.token)
 
-    let lights: LightController
+    let lights: EffectController
     if options.simulate {
-        lights = LoggingLightController(logger: logger)
+        lights = LoggingEffectController(logger: logger)
     } else {
-        let haLights = HomeAssistantLightController(baseURL: options.baseURL,
+        let haLights = HomeAssistantEffectController(baseURL: options.baseURL,
                                                    token: options.token,
                                                    logger: logger)
         lights = options.verbose ?
-            MultiLightController([haLights, LoggingLightController(logger: logger)]) :
+            MultiEffectController([haLights, LoggingEffectController(logger: logger)]) :
             haLights
     }
 

--- a/maestro/swift/Sources/Core/SideEffect.swift
+++ b/maestro/swift/Sources/Core/SideEffect.swift
@@ -5,7 +5,7 @@ public enum SideEffect {
 }
 
 extension SideEffect {
-    func perform(using lights: LightController) {
+    func perform(using lights: EffectController) {
         switch self {
         case .setLight(let state):
             lights.setLightState(state: state)

--- a/maestro/swift/Sources/Lights/EffectController.swift
+++ b/maestro/swift/Sources/Lights/EffectController.swift
@@ -1,5 +1,5 @@
 // LIGHTS:
-public protocol LightController {
+public protocol EffectController {
     func setLightState(state: LightState)
     func stopAllDynamicScenes()
     func setInputBoolean(entityId: String, to state: Bool)

--- a/maestro/swift/Sources/Lights/HomeAssistantEffectController.swift
+++ b/maestro/swift/Sources/Lights/HomeAssistantEffectController.swift
@@ -3,7 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public final class HomeAssistantLightController: LightController {
+public final class HomeAssistantEffectController: EffectController {
     private let baseURL: URL
     private let token: String?
     private let session: URLSession

--- a/maestro/swift/Sources/Lights/LoggingEffectController.swift
+++ b/maestro/swift/Sources/Lights/LoggingEffectController.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// `LightController` implementation that prints light commands instead of
+/// `EffectController` implementation that prints light commands instead of
 /// sending them to Home Assistant. Useful for debugging.
-public final class LoggingLightController: LightController {
+public final class LoggingEffectController: EffectController {
     private let logger: Logger
 
     public init(logger: Logger = Logger(pusher: nil)) {

--- a/maestro/swift/Sources/Lights/MultiEffectController.swift
+++ b/maestro/swift/Sources/Lights/MultiEffectController.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// `LightController` that forwards commands to multiple controllers.
-public final class MultiLightController: LightController {
-    private let controllers: [LightController]
+/// `EffectController` that forwards commands to multiple controllers.
+public final class MultiEffectController: EffectController {
+    private let controllers: [EffectController]
 
-    public init(_ controllers: [LightController]) {
+    public init(_ controllers: [EffectController]) {
         self.controllers = controllers
     }
 

--- a/maestro/swift/Tests/maestroTests/MaestroDynamicScenesTests.swift
+++ b/maestro/swift/Tests/maestroTests/MaestroDynamicScenesTests.swift
@@ -8,7 +8,7 @@ final class MaestroDynamicScenesTests: XCTestCase {
         func fetchAllStates() -> Result<HomeAssistantStateMap, Error> { .success(states) }
     }
 
-    final class DummyLightController: LightController {
+    final class DummyEffectController: EffectController {
         var stopCount = 0
         var boolChanges: [(String, Bool)] = []
         func setLightState(state: LightState) {}
@@ -37,7 +37,7 @@ final class MaestroDynamicScenesTests: XCTestCase {
             "input_select.living_scene": ["state": "normal"],
             "input_boolean.living_scene_auto": ["state": "on"]
         ])
-        let lights = DummyLightController()
+        let lights = DummyEffectController()
         let maestro = Maestro(states: provider, lights: lights, program: StubProgram(), logger: Logger(pusher: nil))
         maestro.run()
         XCTAssertEqual(lights.stopCount, 1)
@@ -48,7 +48,7 @@ final class MaestroDynamicScenesTests: XCTestCase {
             "input_select.living_scene": ["state": "preset"],
             "input_boolean.living_scene_auto": ["state": "on"]
         ])
-        let lights = DummyLightController()
+        let lights = DummyEffectController()
         let maestro = Maestro(states: provider, lights: lights, program: StubProgram(), logger: Logger(pusher: nil))
         maestro.run()
         XCTAssertEqual(lights.stopCount, 0)
@@ -60,7 +60,7 @@ final class MaestroDynamicScenesTests: XCTestCase {
             "binary_sensor.kitchen_espresence": ["state": "off"],
             "input_boolean.kitchen_extra_brightness": ["state": "on"]
         ])
-        let lights = DummyLightController()
+        let lights = DummyEffectController()
         let maestro = Maestro(states: provider, lights: lights, program: StubProgram(), logger: Logger(pusher: nil))
         maestro.run()
         XCTAssertEqual(lights.boolChanges.first?.0, "input_boolean.kitchen_extra_brightness")


### PR DESCRIPTION
## Summary
- rename LightController protocol to EffectController
- rename controller implementations
- update Maestro to use EffectController
- adjust docs and tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68572655a3748326a90b479eaf5c7055