### PR TITLE
Move side effect code into dedicated step

### DIFF
--- a/maestro/swift/Sources/Programs/Steps/InitialEffectsStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/InitialEffectsStep.swift
@@ -1,0 +1,18 @@
+struct InitialEffectsStep: ProgramStep {
+    let name = "initialEffects"
+
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+        var effects = effects
+
+        if !context.environment.kitchenPresence {
+            effects.append(.setInputBoolean(entityId: "input_boolean.kitchen_extra_brightness", state: false))
+        }
+
+        if context.environment.autoMode && context.scene != .preset {
+            effects.append(.stopAllDynamicScenes)
+        }
+
+        return (changes, effects)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add InitialEffectsStep for kitchen presence and dynamic scene side effects
- run that step first in the default program
- stop running other steps when auto mode is disabled

## Testing
- `swift test --package-path maestro/swift`

------
https://chatgpt.com/codex/tasks/task_e_68572fccb4cc83268c9f7bfe9f27f975