### PR TITLE
Remove transition parameter from program steps

### DIFF
--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -23,7 +23,6 @@ public struct LightProgramDefault: LightProgram {
 
     public func compute(context: StateContext) -> ProgramOutput {
         let states = context.states
-        let transition = context.environment.lightTransition
 
         var changes: [LightState] = []
         var effects: [SideEffect] = []
@@ -31,8 +30,7 @@ public struct LightProgramDefault: LightProgram {
         for step in steps {
             let result = step.apply(changes: changes,
                                     effects: effects,
-                                    context: context,
-                                    transition: transition)
+                                    context: context)
             changes = result.0
             effects = result.1
             if !context.environment.autoMode { break }

--- a/maestro/swift/Sources/Programs/ProgramStep.swift
+++ b/maestro/swift/Sources/Programs/ProgramStep.swift
@@ -1,4 +1,4 @@
 public protocol ProgramStep {
     var name: String { get }
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect])
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect])
 }

--- a/maestro/swift/Sources/Programs/Steps/BaseSceneStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/BaseSceneStep.swift
@@ -1,7 +1,7 @@
 struct BaseSceneStep: ProgramStep {
     let name = "baseScene"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
         var changes = changes
         changes = sceneChanges(scene: context.scene, environment: context.environment)
         return (changes, effects)

--- a/maestro/swift/Sources/Programs/Steps/GlobalBrightnessStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/GlobalBrightnessStep.swift
@@ -3,8 +3,8 @@ import Foundation
 struct GlobalBrightnessStep: ProgramStep {
     let name = "globalBrightness"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
-        let adjusted = scaleBrightness(changes: changes, states: context.states, transition: transition)
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
+        let adjusted = scaleBrightness(changes: changes, states: context.states, transition: context.environment.lightTransition)
         return (adjusted, effects)
     }
 

--- a/maestro/swift/Sources/Programs/Steps/InitialEffectsStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/InitialEffectsStep.swift
@@ -1,7 +1,7 @@
 struct InitialEffectsStep: ProgramStep {
     let name = "initialEffects"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
         var effects = effects
 
         if !context.environment.kitchenPresence {

--- a/maestro/swift/Sources/Programs/Steps/KitchenSinkStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/KitchenSinkStep.swift
@@ -1,7 +1,7 @@
 struct KitchenSinkStep: ProgramStep {
     let name = "kitchenSink"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
         var changes = changes
         applyKitchenSink(scene: context.scene, environment: context.environment, changes: &changes)
         return (changes, effects)

--- a/maestro/swift/Sources/Programs/Steps/TvShelfGroupStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/TvShelfGroupStep.swift
@@ -1,8 +1,8 @@
 struct TvShelfGroupStep: ProgramStep {
     let name = "tvShelfGroup"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
-        let result = expandTvShelfGroup(changes: changes, environment: context.environment, transition: transition)
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
+        let result = expandTvShelfGroup(changes: changes, environment: context.environment, transition: context.environment.lightTransition)
         return (result, effects)
     }
 

--- a/maestro/swift/Sources/Programs/Steps/WledMainStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/WledMainStep.swift
@@ -1,8 +1,8 @@
 struct WledMainStep: ProgramStep {
     let name = "wledMain"
 
-    func apply(changes: [LightState], effects: [SideEffect], context: StateContext, transition: Double) -> ([LightState], [SideEffect]) {
-        let result = ensureWledMain(changes: changes, transition: transition)
+    func apply(changes: [LightState], effects: [SideEffect], context: StateContext) -> ([LightState], [SideEffect]) {
+        let result = ensureWledMain(changes: changes, transition: context.environment.lightTransition)
         return (result, effects)
     }
 


### PR DESCRIPTION
## Summary
- simplify program step interface
- update default program to use the new interface
- update all steps to read transition from context instead of a parameter

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_68575671fbec8326a53cec10decae0f1