### PR TITLE
Add verbose logging at pipeline steps

### DIFF
--- a/maestro/swift/Sources/Core/SideEffect.swift
+++ b/maestro/swift/Sources/Core/SideEffect.swift
@@ -4,6 +4,19 @@ public enum SideEffect {
     case setInputBoolean(entityId: String, state: Bool)
 }
 
+extension SideEffect: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .setLight(let state):
+            return "setLight(\(state.description))"
+        case .stopAllDynamicScenes:
+            return "stopAllDynamicScenes"
+        case .setInputBoolean(let entityId, let state):
+            return "setInputBoolean(\(entityId) -> \(state))"
+        }
+    }
+}
+
 extension SideEffect {
     func perform(using lights: EffectController) {
         switch self {

--- a/maestro/swift/Sources/Lights/LightState.swift
+++ b/maestro/swift/Sources/Lights/LightState.swift
@@ -28,6 +28,22 @@ public struct LightState {
     }
 }
 
+extension LightState: CustomStringConvertible {
+    public var description: String {
+        let stateStr = on ? "on" : "off"
+        var parts: [String] = ["\(entityId) -> \(stateStr)"]
+        if let b = brightness { parts.append("brightness:\(b)") }
+        if let ct = colorTemperature { parts.append("colorTemp:\(ct)") }
+        if let rgb = rgbColor { parts.append("rgb:(\(rgb.0),\(rgb.1),\(rgb.2))") }
+        if let rgbw = rgbwColor {
+            parts.append("rgbw:(\(rgbw.0),\(rgbw.1),\(rgbw.2),\(rgbw.3))")
+        }
+        if let effect = effect { parts.append("effect:\(effect)") }
+        if let t = transitionDuration { parts.append("transition:\(t)") }
+        return parts.joined(separator: " ")
+    }
+}
+
 public extension Array where Element == LightState {
     mutating func on(_ entityId: String,
                      brightness: Int? = nil,


### PR DESCRIPTION
## Summary
- add descriptions for `LightState` and `SideEffect`
- log pipeline stages in `Maestro.run`

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_68575f263e548326bb3953db8f8fc215