### PR TITLE
Parallelize side effect HTTP calls

### DIFF
--- a/docs/side-effects.md
+++ b/docs/side-effects.md
@@ -2,4 +2,4 @@
 
 Maestro separates decision making from performing actions. During the PROGRAM step each `ProgramStep` may append side effects that should happen later. A side effect is anything other than returning the final light state (for example updating helper booleans or stopping dynamic scenes).
 
-`ProgramStep.apply` returns `(changes: [LightState], effects: [SideEffect])`. The pipeline passes the current lists to each step so it can append new effects without modifying earlier ones. After every step has run, `LightProgram.compute` executes the gathered effects followed by the light updates.
+`ProgramStep.apply` returns `(changes: [LightState], effects: [SideEffect])`. The pipeline passes the current lists to each step so it can append new effects without modifying earlier ones. After every step has run, `LightProgram.compute` executes the gathered effects followed by the light updates. All side effect HTTP requests are dispatched concurrently so that network latency does not slow down the loop.

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -54,10 +54,16 @@ public final class Maestro {
             if verbose { logger.log("CHANGESET: \(lightEffects.count) changes after simplification") }
 
             let allEffects = output.sideEffects + lightEffects
+            let group = DispatchGroup()
             for effect in allEffects {
-                if verbose { logger.log("LIGHTS: \(effect.description)") }
-                effect.perform(using: effects)
+                group.enter()
+                DispatchQueue.global().async {
+                    if self.verbose { self.logger.log("LIGHTS: \(effect.description)") }
+                    effect.perform(using: self.effects)
+                    group.leave()
+                }
             }
+            group.wait()
         case .failure(let error):
             logger.error("Failed to fetch home assistant states: \(error)")
         }

--- a/maestro/swift/Sources/Core/Maestro.swift
+++ b/maestro/swift/Sources/Core/Maestro.swift
@@ -58,7 +58,7 @@ public final class Maestro {
             for effect in allEffects {
                 group.enter()
                 DispatchQueue.global().async {
-                    if self.verbose { self.logger.log("LIGHTS: \(effect.description)") }
+                    if self.verbose { self.logger.log("EFFECT: \(effect.description)") }
                     effect.perform(using: self.effects)
                     group.leave()
                 }

--- a/maestro/swift/Sources/Lights/MultiEffectController.swift
+++ b/maestro/swift/Sources/Lights/MultiEffectController.swift
@@ -9,38 +9,20 @@ public final class MultiEffectController: EffectController {
     }
 
     public func setLightState(state: LightState) {
-        let group = DispatchGroup()
         for controller in controllers {
-            group.enter()
-            DispatchQueue.global().async {
-                controller.setLightState(state: state)
-                group.leave()
-            }
+            controller.setLightState(state: state)
         }
-        group.wait()
     }
 
     public func stopAllDynamicScenes() {
-        let group = DispatchGroup()
         for controller in controllers {
-            group.enter()
-            DispatchQueue.global().async {
-                controller.stopAllDynamicScenes()
-                group.leave()
-            }
+            controller.stopAllDynamicScenes()
         }
-        group.wait()
     }
 
     public func setInputBoolean(entityId: String, to state: Bool) {
-        let group = DispatchGroup()
         for controller in controllers {
-            group.enter()
-            DispatchQueue.global().async {
-                controller.setInputBoolean(entityId: entityId, to: state)
-                group.leave()
-            }
+            controller.setInputBoolean(entityId: entityId, to: state)
         }
-        group.wait()
     }
 }

--- a/maestro/swift/Sources/Lights/MultiEffectController.swift
+++ b/maestro/swift/Sources/Lights/MultiEffectController.swift
@@ -9,20 +9,38 @@ public final class MultiEffectController: EffectController {
     }
 
     public func setLightState(state: LightState) {
+        let group = DispatchGroup()
         for controller in controllers {
-            controller.setLightState(state: state)
+            group.enter()
+            DispatchQueue.global().async {
+                controller.setLightState(state: state)
+                group.leave()
+            }
         }
+        group.wait()
     }
 
     public func stopAllDynamicScenes() {
+        let group = DispatchGroup()
         for controller in controllers {
-            controller.stopAllDynamicScenes()
+            group.enter()
+            DispatchQueue.global().async {
+                controller.stopAllDynamicScenes()
+                group.leave()
+            }
         }
+        group.wait()
     }
 
     public func setInputBoolean(entityId: String, to state: Bool) {
+        let group = DispatchGroup()
         for controller in controllers {
-            controller.setInputBoolean(entityId: entityId, to: state)
+            group.enter()
+            DispatchQueue.global().async {
+                controller.setInputBoolean(entityId: entityId, to: state)
+                group.leave()
+            }
         }
+        group.wait()
     }
 }


### PR DESCRIPTION
## Summary
- execute effect controller methods concurrently via DispatchGroup
- run side effects concurrently in `Maestro.run`
- document concurrent execution in side effects guide

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685790a586dc8326bc744bbf118613bb