### PR TITLE
Log program step names

### DIFF
--- a/maestro/swift/Sources/Core/MaestroFactory.swift
+++ b/maestro/swift/Sources/Core/MaestroFactory.swift
@@ -24,7 +24,10 @@ func makeMaestro(from options: MaestroOptions) -> Maestro {
         .split(separator: ",")
         .map { $0.trimmingCharacters(in: .whitespaces).lowercased() } ?? []
     let steps = stepStrings.compactMap(LightProgramDefault.step(named:))
-    let program = LightProgramDefault(steps: steps.isEmpty ? LightProgramDefault.defaultSteps : steps)
+    let program = LightProgramDefault(
+        steps: steps.isEmpty ? LightProgramDefault.defaultSteps : steps,
+        logger: options.verbose ? logger : nil
+    )
 
     return Maestro(states: states,
                    effects: effects,

--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -32,7 +32,7 @@ public struct LightProgramDefault: LightProgram {
 
         for step in steps {
             if let logger = logger {
-                logger.log("PROGRAM: \(step.name)")
+                logger.log("STEP: \(step.name)")
             }
             let result = step.apply(changes: changes,
                                     effects: effects,

--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct LightProgramDefault: LightProgram {
     public let name = "default"
     private let steps: [any ProgramStep]
+    private let logger: Logger?
 
     public static let defaultSteps: [any ProgramStep] = [
         InitialEffectsStep(),
@@ -17,8 +18,10 @@ public struct LightProgramDefault: LightProgram {
         defaultSteps.first { $0.name.lowercased() == name.lowercased() }
     }
 
-    public init(steps: [any ProgramStep] = LightProgramDefault.defaultSteps) {
+    public init(steps: [any ProgramStep] = LightProgramDefault.defaultSteps,
+                logger: Logger? = nil) {
         self.steps = steps
+        self.logger = logger
     }
 
     public func compute(context: StateContext) -> ProgramOutput {
@@ -28,6 +31,9 @@ public struct LightProgramDefault: LightProgram {
         var effects: [SideEffect] = []
 
         for step in steps {
+            if let logger = logger {
+                logger.log("PROGRAM: \(step.name)")
+            }
             let result = step.apply(changes: changes,
                                     effects: effects,
                                     context: context)


### PR DESCRIPTION
## Summary
- log step names in the default light program
- forward logger from `MaestroFactory` when verbose logging is on

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685790cceabc832698c8da2c3d3c1d5e