### PR TITLE
Fix color logging for multiline messages

### DIFF
--- a/maestro/swift/Sources/Core/Logger.swift
+++ b/maestro/swift/Sources/Core/Logger.swift
@@ -19,7 +19,10 @@ public struct Logger: @unchecked Sendable {
     }
 
     private func colored(_ text: String, color: String) -> String {
-        return color + text + Color.reset
+        return text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { color + $0 + Color.reset }
+            .joined(separator: "\n")
     }
 
     public func log(_ message: String) {

--- a/maestro/swift/Tests/maestroTests/LoggerColorTests.swift
+++ b/maestro/swift/Tests/maestroTests/LoggerColorTests.swift
@@ -8,6 +8,7 @@ final class LoggerColorTests: XCTestCase {
         dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         block()
         fflush(stdout)
+        pipe.fileHandleForWriting.closeFile()
         dup2(original, STDOUT_FILENO)
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8) ?? ""

--- a/maestro/swift/Tests/maestroTests/LoggerColorTests.swift
+++ b/maestro/swift/Tests/maestroTests/LoggerColorTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import maestro
+
+final class LoggerColorTests: XCTestCase {
+    private func captureOutput(_ block: () -> Void) -> String {
+        let pipe = Pipe()
+        let original = dup(STDOUT_FILENO)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+        block()
+        fflush(stdout)
+        dup2(original, STDOUT_FILENO)
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    func testLinesAreIndividuallyColored() {
+        let logger = Logger(pusher: nil)
+        let output = captureOutput {
+            logger.log("first\nsecond")
+        }
+        let lines = output.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "\n")
+        XCTAssertTrue(lines.allSatisfy { $0.hasPrefix("\u{001B}[36m") && $0.hasSuffix("\u{001B}[0m") })
+    }
+}


### PR DESCRIPTION
## Summary
- handle newline characters when coloring log output
- add tests for the colored logger behavior

## Testing
- `swift test` *(fails: Another instance of SwiftPM is already running)*

------
https://chatgpt.com/codex/tasks/task_e_68578f0dca208326bb56eba4c05092b2