### PR TITLE
Implement group flattening step

### DIFF
--- a/maestro/swift/Sources/Programs/LightProgramDefault.swift
+++ b/maestro/swift/Sources/Programs/LightProgramDefault.swift
@@ -12,7 +12,8 @@ public struct LightProgramDefault: LightProgram {
         { KitchenSinkStep(context: $0) },
         { TvShelfGroupStep(context: $0) },
         { GlobalBrightnessStep(context: $0) },
-        { WledMainStep(context: $0) }
+        { WledMainStep(context: $0) },
+        { FlattenGroupsStep(context: $0) }
     ]
 
     public static func step(named name: String) -> StepFactory? {

--- a/maestro/swift/Sources/Programs/Steps/FlattenGroupsStep.swift
+++ b/maestro/swift/Sources/Programs/Steps/FlattenGroupsStep.swift
@@ -1,0 +1,110 @@
+struct FlattenGroupsStep: ProgramStep {
+    let name = "flattenGroups"
+    let context: StateContext
+
+    init(context: StateContext) {
+        self.context = context
+    }
+
+    func process(_ effects: [SideEffect]) -> [SideEffect] {
+        let lights = flatten(changes: effects.lights)
+        var other = effects.nonLights
+        other.appendLights(lights)
+        return other
+    }
+
+    private func flatten(changes: [LightState]) -> [LightState] {
+        var explicit: [String: LightState] = [:]
+        var explicitOrder: [String: Int] = [:]
+        var groups: [(LightState, [String])] = []
+        for (index, state) in changes.enumerated() {
+            if let members = FlattenGroupsStep.allLeaves(of: state.entityId) {
+                groups.append((state, members))
+            } else {
+                explicit[state.entityId] = state
+                explicitOrder[state.entityId] = index
+            }
+        }
+        var result: [LightState] = []
+        for (state, members) in groups {
+            let anyExplicit = members.contains { explicit[$0] != nil }
+            if anyExplicit {
+                for m in members {
+                    if explicit[m] == nil {
+                        explicit[m] = LightState(entityId: m,
+                                                on: state.on,
+                                                brightness: state.brightness,
+                                                colorTemperature: state.colorTemperature,
+                                                rgbColor: state.rgbColor,
+                                                rgbwColor: state.rgbwColor,
+                                                effect: state.effect,
+                                                transitionDuration: state.transitionDuration)
+                        explicitOrder[m] = explicitOrder[state.entityId] ?? Int.max
+                    }
+                }
+            } else {
+                result.append(state)
+            }
+        }
+        for id in explicitOrder.keys.sorted(by: { explicitOrder[$0]! < explicitOrder[$1]! }) {
+            if let st = explicit[id] {
+                result.append(st)
+            }
+        }
+        return result
+    }
+
+    private static let groupMap: [String: [String]] = [
+        "light.tv_shelf_group": [
+            "light.wled_tv_shelf_1",
+            "light.wled_tv_shelf_2",
+            "light.wled_tv_shelf_3",
+            "light.wled_tv_shelf_4",
+            "light.wled_tv_shelf_5"
+        ],
+        "light.zigbee_hub_estante_lights": [
+            "light.estante_1_light",
+            "light.estante_2_light"
+        ],
+        "light.color_lights_without_tv_light": [
+            "light.dining_table_light",
+            "light.living_art_wall_light",
+            "light.desk_light",
+            "light.corner_light",
+            "light.tripod_lamp",
+            "light.estante_1_light",
+            "light.estante_2_light"
+        ],
+        "light.color_lights": [
+            "light.tv_light",
+            "light.dining_table_light",
+            "light.living_art_wall_light",
+            "light.desk_light",
+            "light.corner_light",
+            "light.tripod_lamp",
+            "light.estante_1_light",
+            "light.estante_2_light"
+        ],
+        "light.living_temperature_lights": [
+            "light.chaise_light",
+            "light.shoes_light",
+            "light.corredor_door_light",
+            "light.entrance_dining_light",
+            "light.living_entry_door_light",
+            "light.living_fireplace_spot"
+        ]
+    ]
+
+    private static func allLeaves(of id: String) -> [String]? {
+        guard let members = groupMap[id] else { return nil }
+        var leaves: [String] = []
+        for m in members {
+            if let sub = allLeaves(of: m) {
+                leaves.append(contentsOf: sub)
+            } else {
+                leaves.append(m)
+            }
+        }
+        return leaves
+    }
+}

--- a/maestro/swift/Tests/maestroTests/FlattenGroupsStepTests.swift
+++ b/maestro/swift/Tests/maestroTests/FlattenGroupsStepTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import maestro
+
+final class FlattenGroupsStepTests: XCTestCase {
+    func testGroupExpandedWhenIndividualOverrides() {
+        let context = StateContext(states: [
+            "input_select.living_scene": ["state": "normal"],
+            "sun.sun": ["state": "below_horizon"],
+            "binary_sensor.living_tv_hyperion_running_condition_for_the_scene": ["state": "off"],
+            "binary_sensor.dining_espresence": ["state": "off"],
+            "binary_sensor.kitchen_espresence": ["state": "off"],
+            "input_boolean.kitchen_extra_brightness": ["state": "off"]
+        ])
+        let diff = LightProgramDefault().compute(context: context).changeset
+        XCTAssertNil(diff.desiredStates.first { $0.entityId == "light.color_lights_without_tv_light" })
+        let corner = diff.desiredStates.first { $0.entityId == "light.corner_light" }
+        XCTAssertEqual(corner?.brightness, 30)
+        let dining = diff.desiredStates.first { $0.entityId == "light.dining_table_light" }
+        XCTAssertEqual(dining?.brightness, 51)
+    }
+}


### PR DESCRIPTION
## Summary
- add FlattenGroupsStep to expand group states when individual lights are updated
- run the new step in `LightProgramDefault`
- test that groups split correctly when a member has a specific state

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6858b0fbe8308326806a9eb65763c243