### PR TITLE
Update web UI design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Replace `8080` with the port specified by `--port` if different.
 If the path is anything other than `/run`, the server responds with `404 Not
 Found`.
 
+### `GET /configure`
+
+Serves a simple web interface to choose which program steps run and in what
+order. Saving changes posts them back asynchronously to persist the selection
+under `/data/step_order.json`.
+
 ## Pipeline
 
 The maestro pipeline consists of 5 steps:

--- a/docs/web-ui-custom-steps.md
+++ b/docs/web-ui-custom-steps.md
@@ -1,0 +1,35 @@
+# Web UI for Custom Program Steps
+
+This document outlines a future feature to expose a small web interface for configuring which `ProgramStep` instances run in the Maestro pipeline. The goal is to allow users to change the order of steps, or disable certain steps entirely, without modifying command line arguments.
+
+## Goals
+
+- Provide a simple UI served by Maestro that lists available steps.
+- Allow users to enable/disable steps and reorder them via drag-and-drop or arrow buttons.
+- Persist the selected order so that subsequent runs reuse it.
+- Use the `--program` command line argument as the initial default sequence. Once the user saves a configuration through the UI, that configuration overrides the default until changed again.
+
+## Proposed Approach
+
+1. **Expose an HTTP page**
+   - Add `webui: http://[HOST]:[PORT:8080]/configure` to `maestro/config.yaml` so Home Assistant shows an "Open Web UI" link.
+   - Provide a `GET /configure` route which serves a basic HTML/JS interface.
+   - Include an endpoint like `POST /configure` to accept the chosen step list.
+     The page should send this request asynchronously using `fetch` so the UI
+     doesn't reload.
+
+2. **List available steps**
+   - Read step names from `LightProgramDefault.defaultSteps` using the same lookup logic as the `--program` option.
+   - Display them with controls to reorder or remove each item.
+
+3. **Persist configuration**
+   - Save the selected list under `/data/step_order.json` (or similar) inside the add-on data directory.
+   - At startup, if this file exists, load the steps from it instead of the `--program` argument.
+
+4. **Fallback behaviour**
+   - If no saved configuration is found, build the program from the command line `--program` option.
+   - The first time the UI is used and saved, the stored value replaces the command line default for future runs.
+
+
+This feature will make it easier to experiment with different step combinations without editing configuration files or restarting the add-on with new arguments.
+

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -11,6 +11,7 @@ startup: services
 homeassistant_api: true
 ports:
   8080/tcp: 8080
+webui: http://[HOST]:[PORT:8080]/configure
 image: "ghcr.io/lucasfeijo/{arch}-addon-maestro"
 
 # Default option values exposed to the add-on UI. These are forwarded as

--- a/maestro/swift/Sources/Core/MaestroFactory.swift
+++ b/maestro/swift/Sources/Core/MaestroFactory.swift
@@ -20,9 +20,17 @@ func makeMaestro(from options: MaestroOptions) -> Maestro {
             haEffects
     }
 
-    let stepStrings = options.programName?
-        .split(separator: ",")
-        .map { $0.trimmingCharacters(in: .whitespaces).lowercased() } ?? []
+    let savedNames = StepOrderStorage.load()
+    let stepStrings: [String]
+    if let savedNames, !savedNames.isEmpty {
+        stepStrings = savedNames
+    } else if let program = options.programName {
+        stepStrings = program
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+    } else {
+        stepStrings = []
+    }
     let factories = stepStrings.compactMap(LightProgramDefault.step(named:))
     let program = LightProgramDefault(
         steps: factories.isEmpty ? LightProgramDefault.defaultSteps : factories,

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -10,10 +10,35 @@ import ucrt
 #else
 #error("Unknown platform")
 #endif
-/// Minimal HTTP server handling GET requests from Home Assistant.
+
+private func configureHTML(stepNames: [String]) -> String {
+    let data = try! JSONEncoder().encode(stepNames)
+    let json = String(data: data, encoding: .utf8) ?? "[]"
+    return """
+    <!DOCTYPE html>
+    <html><head><meta charset='utf-8'/>
+    <title>Configure Maestro</title>
+    <style>li{list-style:none;padding:4px;margin:2px;background:#eee;}li.drag{opacity:0.5;}</style>
+    </head><body>
+    <h1>Program Steps</h1>
+    <ul id='list'></ul>
+    <button id='save'>Save</button>
+    <script>
+    const list=document.getElementById('list');
+    const names = \(json);
+    function render(){list.innerHTML='';names.forEach(n=>{const li=document.createElement('li');li.textContent=n;li.draggable=true;li.dataset.name=n;list.appendChild(li);});}
+    let drag;list.addEventListener('dragstart',e=>{drag=e.target;e.target.classList.add('drag');});
+    list.addEventListener('dragend',e=>{e.target.classList.remove('drag');});
+    list.addEventListener('dragover',e=>e.preventDefault());
+    list.addEventListener('drop',e=>{e.preventDefault();if(e.target.tagName==='LI'&&drag){list.insertBefore(drag,e.target.nextSibling);}});
+    document.getElementById('save').onclick=async()=>{const ordered=Array.from(list.children).map(li=>li.dataset.name);await fetch('/configure',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(ordered)});};
+    render();
+    </script></body></html>
+    """
+}
+
+/// Minimal HTTP server handling GET/POST requests from Home Assistant.
 func startServer(on port: Int32, maestro: Maestro) throws {
-    // SOCK_STREAM may be an enum or an Int32 depending on the libc headers
-    // being used. Convert it to Int32 in a way that works for both cases.
     let sockStream: Int32 = withUnsafeBytes(of: SOCK_STREAM) { $0.load(as: Int32.self) }
     let serverFD = socket(AF_INET, sockStream, 0)
     guard serverFD >= 0 else { fatalError("Unable to create socket") }
@@ -40,25 +65,45 @@ func startServer(on port: Int32, maestro: Maestro) throws {
         let clientFD = accept(serverFD, &clientAddr, &len)
         if clientFD < 0 { continue }
 
-        var buffer = [UInt8](repeating: 0, count: 1024)
-        let count = read(clientFD, &buffer, 1024)
+        var buffer = [UInt8](repeating: 0, count: 2048)
+        let count = read(clientFD, &buffer, 2048)
 
         var statusLine = "HTTP/1.1 200 OK"
         var body = "OK"
 
         if count > 0 {
             let request = String(decoding: buffer[0..<count], as: UTF8.self)
-            if request.hasPrefix("GET ") {
+            if request.hasPrefix("GET ") || request.hasPrefix("POST ") {
                 if let firstLine = request.components(separatedBy: "\r\n").first,
                    let range = firstLine.range(of: " ") {
                     let start = firstLine.index(after: range.lowerBound)
                     let end = firstLine.range(of: " ", range: start..<firstLine.endIndex)?.lowerBound ?? firstLine.endIndex
-                    let path = firstLine[start..<end]
-                    if path == "/run" {
-                        maestro.run()
-                    } else {
-                        statusLine = "HTTP/1.1 404 Not Found"
-                        body = "Not Found"
+                    let path = String(firstLine[start..<end])
+
+                    if request.hasPrefix("GET ") {
+                        if path == "/run" {
+                            maestro.run()
+                        } else if path == "/configure" {
+                            let dummy = StateContext(states: [:])
+                            let names = LightProgramDefault.defaultSteps.map { $0(dummy).name }
+                            body = configureHTML(stepNames: names)
+                        } else {
+                            statusLine = "HTTP/1.1 404 Not Found"
+                            body = "Not Found"
+                        }
+                    } else if request.hasPrefix("POST ") {
+                        if path == "/configure" {
+                            if let bodyRange = request.range(of: "\r\n\r\n") {
+                                let jsonBody = request[bodyRange.upperBound...]
+                                if let data = jsonBody.data(using: .utf8),
+                                   let names = try? JSONDecoder().decode([String].self, from: data) {
+                                    StepOrderStorage.save(names)
+                                }
+                            }
+                        } else {
+                            statusLine = "HTTP/1.1 404 Not Found"
+                            body = "Not Found"
+                        }
                     }
                 }
             }

--- a/maestro/swift/Sources/Core/StepOrderStorage.swift
+++ b/maestro/swift/Sources/Core/StepOrderStorage.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum StepOrderStorage {
+    private static var fileURL: URL {
+        if let env = ProcessInfo.processInfo.environment["STEP_ORDER_PATH"], !env.isEmpty {
+            return URL(fileURLWithPath: env)
+        }
+        return URL(fileURLWithPath: "/data/step_order.json")
+    }
+
+    static func load() -> [String]? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode([String].self, from: data)
+    }
+
+    static func save(_ steps: [String]) {
+        if let data = try? JSONEncoder().encode(steps) {
+            try? data.write(to: fileURL, options: [.atomic])
+        }
+    }
+}

--- a/maestro/swift/Tests/maestroTests/MaestroFactoryTests.swift
+++ b/maestro/swift/Tests/maestroTests/MaestroFactoryTests.swift
@@ -20,4 +20,21 @@ final class MaestroFactoryTests: XCTestCase {
         let defaultNames = LightProgramDefault.defaultSteps.map { $0(dummy).name }
         XCTAssertEqual(names, defaultNames)
     }
+
+    func testSavedStepOrderOverridesProgram() {
+        let path = NSTemporaryDirectory() + "steps.json"
+        setenv("STEP_ORDER_PATH", path, 1)
+        StepOrderStorage.save(["globalbrightness"])
+        defer { unlink(path) }
+
+        let options = parseArguments(["maestro", "--program", "basescene"])
+        let maestroInstance = makeMaestro(from: options)
+        let mirror = Mirror(reflecting: maestroInstance)
+        let program = mirror.children.first { $0.label == "program" }!.value as! LightProgramDefault
+        let programMirror = Mirror(reflecting: program)
+        let factories = programMirror.children.first { $0.label == "steps" }!.value as! [LightProgramDefault.StepFactory]
+        let dummy = StateContext(states: [:])
+        let names = factories.map { $0(dummy).name }
+        XCTAssertEqual(names.first, "globalBrightness")
+    }
 }


### PR DESCRIPTION
## Summary
- implement /configure web page with async step saving
- persist saved steps to `/data/step_order.json`
- load saved steps in `makeMaestro`
- document async POST requirement and new GET route

## Testing
- `swift test --package-path maestro/swift`

------
https://chatgpt.com/codex/tasks/task_e_6858b770ad8c8326975d9c4a30432f7b