### PR TITLE
Add simple web UI for maestro add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Replace `8080` with the port specified by `--port` if different.
 If the path is anything other than `/run`, the server responds with `404 Not
 Found`.
 
+### `GET /`
+
+Opens a simple HTML page displaying the current maestro options. This page
+includes links to trigger `/run` directly.
+
 ## Pipeline
 
 The maestro pipeline consists of 5 steps:

--- a/maestro/swift/Sources/Core/main.swift
+++ b/maestro/swift/Sources/Core/main.swift
@@ -3,6 +3,6 @@ import Foundation
 let options = parseArguments(CommandLine.arguments)
 let maestro = makeMaestro(from: options)
 #if !TESTING
-try startServer(on: options.port, maestro: maestro)
+try startServer(on: options.port, maestro: maestro, options: options)
 #endif
 


### PR DESCRIPTION
## Summary
- serve a basic HTML page via the HTTP server
- list maestro options and link to `/run`
- document the new web UI in the README

## Testing
- `swift test --package-path maestro/swift`
- `swift build --package-path maestro/swift`


------
https://chatgpt.com/codex/tasks/task_e_685a332cd04c832694220e0af9d72da6