### PR TITLE
Redirect /run to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The package builds on Linux and macOS. On macOS the POSIX server code uses the
 
 ### `GET /run`
 
-This route triggers a run of the maestro pipeline.
+This route triggers a run of the maestro pipeline and then responds with a
+`302 Found` redirect to `/`.
 
 Example request:
 
@@ -60,8 +61,8 @@ curl http://localhost:8080/run
 ```
 Replace `8080` with the port specified by `--port` if different.
 
-If the path is anything other than `/run`, the server responds with `404 Not
-Found`.
+If the path is anything other than `/run` or `/`, the server responds with
+`404 Not Found`.
 
 ### `GET /`
 

--- a/maestro/swift/Sources/Core/StartServer.swift
+++ b/maestro/swift/Sources/Core/StartServer.swift
@@ -58,6 +58,9 @@ func startServer(on port: Int32, maestro: Maestro, options: MaestroOptions) thro
                     switch path {
                     case "/run":
                         maestro.run()
+                        statusLine = "HTTP/1.1 302 Found"
+                        headers = ["Location: /"]
+                        body = ""
                     case "/":
                         statusLine = "HTTP/1.1 200 OK"
                         headers = ["Content-Type: text/html; charset=utf-8"]


### PR DESCRIPTION
## Summary
- update HTTP server to return a redirect after /run
- document the redirect behaviour in README

## Testing
- `swift test --package-path maestro/swift`

------
https://chatgpt.com/codex/tasks/task_e_685a36ded5008326ad91e927c3bdbf27